### PR TITLE
chore: release v2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ wheels/
 *.egg
 logs/
 records/
+sample/
 release/
 resources/*
 
@@ -52,6 +53,8 @@ ENV/
 
 # Codec build artifacts
 .codecbuild/
+tetraear/tetra_codec/bin/cdecoder
+tetraear/tetra_codec/bin/sdecoder
 
 # Development tools
 dev_tools/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # TetraEar Changelog
 
+## Version 2.3 - February 2026
+
+### 🐛 Bug Fixes
+- **TCH voice path**: Build ETSI codec blocks from lower-MAC Type-4 bits and fix fallback extraction to restore audio output.
+- **MAC fragmentation**: Correct MAC-FRAG/MAC-END handling to avoid duplicate or truncated SDS reassembly.
+- **CMCE parsing**: Improve call control decoding with CRC-tolerant SSI voting to reduce wrong GSSI/ISSI and network IDs.
+
+### ✨ New Features
+- **Pure-Python lower MAC/FEC**: Added deinterleaving, depuncturing, CRC, training sequence detection, and traffic codec input generation.
+- **Offline IQ analyzer**: New `analyze_iq.py` with auto center-frequency detection, multi-carrier decoding, and log comparison.
+- **Codec installer script**: `scripts/install_tetra_codec.sh` downloads the ETSI reference codec and builds `cdecoder`/`sdecoder`.
+
+### 🔧 Improvements
+- **Soft-bit decoding**: Decoder can use symbol confidence for better FEC performance.
+- **Multi-carrier tracking**: Carrier offsets tracked via channel allocations to follow hopping systems.
+- **Signal processing fallback**: Resampling/filtering now works without SciPy.
+
 ## Version 2.2 - December 2025
 
 ### 📦 Release

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,55 @@
-# TETRA Decoder Pro - Release Notes v2.1
+# TETRA Decoder Pro - Release Notes v2.3
 
-## December 23-24, 2025
+## February 13, 2026
+
+---
+
+## ✅ **RELEASE HIGHLIGHTS**
+
+- Working TCH voice decode via lower-MAC FEC + ETSI codec block mapping
+- Cleaner network identity + call control parsing (MCC/MNC, GSSI, ISSI)
+- New offline IQ analyzer with multi-carrier support and codec installer script
+
+---
+
+## 🔧 **Critical Fixes**
+
+### 1. **TCH Voice Decode (Audio Restore)**
+**Problem:** Voice bursts were decoding to silence or had no valid codec input.
+
+**Solution:**
+- Added lower-MAC FEC decoding with training sequence detection
+- Build ETSI `cdecoder` input blocks from Type-4 bits
+- Fixed fallback symbol-based extraction for traffic bursts
+
+**Result:** Traffic channels now generate consistent codec input and audible audio.
+
+### 2. **MAC Fragment Reassembly**
+**Problem:** MAC-FRAG/MAC-END messages were occasionally truncated or duplicated.
+
+**Solution:** Fixed MAC-END length handling and fragment state resets.
+
+**Result:** SDS and fragmented messages reassemble cleanly.
+
+### 3. **CMCE / Call Control Parsing**
+**Problem:** Wrong GSSI/ISSI or MCC/MNC occasionally surfaced due to weak frames.
+
+**Solution:** Added CMCE parsing with CRC-tolerant SSI voting and stronger validation.
+
+**Result:** More stable network identity and call metadata.
+
+---
+
+## 🆕 **New Features**
+
+- **Pure-Python lower MAC/FEC pipeline**: Deinterleaving, depuncturing, CRC, and traffic codec input generation.
+- **Offline IQ analyzer (`analyze_iq.py`)**: Auto center-frequency detection, multi-carrier decoding, and log comparison.
+- **Codec installer script**: `scripts/install_tetra_codec.sh` downloads the ETSI reference codec and builds `cdecoder`/`sdecoder`.
+- **Soft-bit decoding**: Symbol confidence now feeds the decoder for improved FEC performance.
+
+---
+
+## December 23-24, 2025 (v2.1)
 
 ---
 

--- a/analyze_iq.py
+++ b/analyze_iq.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""
+Offline IQ analyzer for TETRA recordings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import wave
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+from tetraear.audio.tch import TchFrameAssembler
+from tetraear.audio.voice import VoiceProcessor
+from tetraear.core.decoder import TetraDecoder
+from tetraear.signal.processor import SignalProcessor
+
+
+def _dtype_from_width(width: int) -> np.dtype:
+    if width == 1:
+        return np.uint8
+    if width == 2:
+        return np.int16
+    if width == 4:
+        return np.int32
+    raise ValueError(f"Unsupported sample width: {width}")
+
+
+def _scale_samples(samples: np.ndarray, width: int) -> np.ndarray:
+    if width == 1:
+        return (samples.astype(np.float32) - 128.0) / 128.0
+    if width == 2:
+        return samples.astype(np.float32) / 32768.0
+    if width == 4:
+        return samples.astype(np.float32) / 2147483648.0
+    return samples.astype(np.float32)
+
+
+def iter_iq_samples(path: Path, chunk_frames: int) -> Iterable[np.ndarray]:
+    with wave.open(str(path), "rb") as wf:
+        channels = wf.getnchannels()
+        width = wf.getsampwidth()
+        dtype = _dtype_from_width(width)
+        while True:
+            raw = wf.readframes(chunk_frames)
+            if not raw:
+                break
+            data = np.frombuffer(raw, dtype=dtype)
+            if channels == 2:
+                i = data[0::2]
+                q = data[1::2]
+            elif channels == 1:
+                if len(data) % 2 != 0:
+                    data = data[:-1]
+                i = data[0::2]
+                q = data[1::2]
+            else:
+                raise ValueError(f"Unsupported channel count: {channels}")
+            i = _scale_samples(i, width)
+            q = _scale_samples(q, width)
+            yield i + 1j * q
+
+
+def parse_reference_logs(paths: list[Path]) -> dict:
+    mccs = set()
+    mncs = set()
+    groups = set()
+    issi = set()
+
+    mcc_re = re.compile(r"MCC:\s*(\d+)")
+    mnc_re = re.compile(r"MNC:\s*(\d+)")
+    group_re = re.compile(r"Group:\s*(\d+)")
+    issi_re = re.compile(r"ISSI:\s*(\d+)")
+    calling_re = re.compile(r"Calling ISSI:\s*(\d+)")
+
+    for path in paths:
+        for line in path.read_text(errors="ignore").splitlines():
+            if m := mcc_re.search(line):
+                mccs.add(int(m.group(1)))
+            if m := mnc_re.search(line):
+                mncs.add(int(m.group(1)))
+            if m := group_re.search(line):
+                groups.add(int(m.group(1)))
+            if m := issi_re.search(line):
+                issi.add(int(m.group(1)))
+            if m := calling_re.search(line):
+                issi.add(int(m.group(1)))
+
+    return {
+        "mcc": mccs,
+        "mnc": mncs,
+        "groups": groups,
+        "issi": issi,
+    }
+
+
+def guess_center_freq(path: Path) -> float | None:
+    match = re.search(r"(\d+)Hz", path.name)
+    if match:
+        return float(match.group(1))
+    nums = re.findall(r"(\d{6,})", path.name)
+    if nums:
+        return float(nums[-1])
+    return None
+
+
+CARRIER_OFFSET_HZ = (0, 6250, -6250, 12500)
+
+
+def tetra_dl_carrier_hz(band: int, carrier: int, offset: int) -> float:
+    base = band * 100_000_000
+    return float(base + carrier * 25_000 + CARRIER_OFFSET_HZ[offset & 3])
+
+
+def estimate_freq_offset(samples: np.ndarray, sample_rate: int, search_hz: int = 100000) -> float:
+    """Estimate carrier offset by finding the strongest spectral peak."""
+    if samples is None or len(samples) == 0:
+        return 0.0
+    n = min(len(samples), 16384)
+    spectrum = np.fft.fftshift(np.fft.fft(samples[:n]))
+    power = np.abs(spectrum)
+    freqs = np.fft.fftshift(np.fft.fftfreq(n, d=1 / sample_rate))
+    mask = (freqs >= -search_hz) & (freqs <= search_hz)
+    if not np.any(mask):
+        return 0.0
+    idx = np.argmax(power[mask])
+    return float(freqs[mask][idx])
+
+
+def estimate_freq_candidates(samples: np.ndarray, sample_rate: int, search_hz: int = 150000, top_n: int = 5) -> list[float]:
+    if samples is None or len(samples) == 0:
+        return [0.0]
+    n = min(len(samples), 16384)
+    spectrum = np.fft.fftshift(np.fft.fft(samples[:n]))
+    power = np.abs(spectrum)
+    freqs = np.fft.fftshift(np.fft.fftfreq(n, d=1 / sample_rate))
+    mask = (freqs >= -search_hz) & (freqs <= search_hz)
+    freqs = freqs[mask]
+    power = power[mask]
+    if len(power) == 0:
+        return [0.0]
+    indices = np.argsort(power)[::-1]
+    candidates: list[float] = []
+    for idx in indices:
+        freq = float(freqs[idx])
+        if all(abs(freq - c) > 2000 for c in candidates):
+            candidates.append(freq)
+        if len(candidates) >= top_n:
+            break
+    return candidates or [0.0]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Analyze TETRA IQ recordings.")
+    parser.add_argument("iq", type=Path, help="Path to IQ WAV file")
+    parser.add_argument("--chunk-frames", type=int, default=256 * 1024, help="Frames per read")
+    parser.add_argument("--max-seconds", type=float, default=None, help="Optional time limit")
+    parser.add_argument("--log", action="append", type=Path, help="Reference log(s) for comparison")
+    parser.add_argument("--save-audio", action="store_true", help="Write decoded voice segments")
+    parser.add_argument("--audio-dir", type=Path, default=Path("records"), help="Directory for audio output")
+    parser.add_argument("--center-freq", type=float, default=None, help="Center frequency in Hz (optional)")
+    parser.add_argument("--band", type=int, default=None, help="TETRA band index (optional)")
+    parser.add_argument("--multi-carrier", action="store_true", help="Enable multi-carrier decoding")
+    parser.add_argument("--max-carriers", type=int, default=6, help="Maximum carriers to decode")
+    args = parser.parse_args()
+
+    iq_path = args.iq
+    if not iq_path.exists():
+        raise SystemExit(f"Missing IQ file: {iq_path}")
+
+    ref = parse_reference_logs(args.log or []) if args.log else None
+
+    with wave.open(str(iq_path), "rb") as wf:
+        sample_rate = wf.getframerate()
+        total_frames = wf.getnframes()
+
+    processor = SignalProcessor(sample_rate=sample_rate)
+    decoder = TetraDecoder(auto_decrypt=False)
+    voice = VoiceProcessor()
+    tch_assembler = TchFrameAssembler()
+
+    mcc_counts: Counter[int] = Counter()
+    mnc_counts: Counter[int] = Counter()
+    group_counts: Counter[int] = Counter()
+    issi_counts: Counter[int] = Counter()
+    frames_seen = 0
+    voice_segments = 0
+
+    max_frames = None
+    if args.max_seconds:
+        max_frames = int(args.max_seconds * sample_rate)
+
+    processed_frames = 0
+    audio_dir = args.audio_dir
+    if args.save_audio:
+        audio_dir.mkdir(parents=True, exist_ok=True)
+
+    center_freq = args.center_freq or guess_center_freq(iq_path)
+    band_guess = args.band
+    if band_guess is None and center_freq is not None:
+        band_guess = int(center_freq // 100_000_000)
+    multi_carrier = args.multi_carrier or center_freq is not None
+
+    sample_iter = iter_iq_samples(iq_path, args.chunk_frames)
+    first_samples = next(sample_iter, None)
+    if first_samples is None:
+        print("No samples read.")
+        return 1
+
+    # Build a longer chunk for frequency estimation (~1 second if possible).
+    search_samples = [first_samples]
+    target_search_len = int(sample_rate)
+    while len(np.concatenate(search_samples)) < target_search_len:
+        nxt = next(sample_iter, None)
+        if nxt is None:
+            break
+        search_samples.append(nxt)
+    search_block = np.concatenate(search_samples)
+
+    # Find best frequency offset using the first chunk.
+    coarse_candidates = estimate_freq_candidates(search_block, sample_rate)
+    candidates = []
+    for base in coarse_candidates:
+        for delta in range(-3000, 3001, 500):
+            candidates.append(base + delta)
+    best_offset = 0.0
+    best_score = -1
+    for offset in candidates:
+        demod = processor.process(search_block, freq_offset=offset)
+        if demod is None or len(demod) < 255:
+            continue
+        frames = decoder.decode(demod, confidences=processor.symbol_confidence)
+        crc_ok = sum(1 for f in frames if f.get("crc_ok"))
+        score = crc_ok if crc_ok > 0 else len(frames)
+        if score > best_score:
+            best_score = score
+            best_offset = offset
+
+    print(f"[INFO] Using frequency offset: {best_offset:.1f} Hz (candidates: {candidates})")
+    if center_freq is not None:
+        print(f"[INFO] Center frequency: {center_freq:.0f} Hz (band guess {band_guess})")
+
+    active_offsets = [best_offset]
+    offset_set = {best_offset}
+
+    def maybe_add_offset(extra: dict) -> None:
+        nonlocal active_offsets
+        if not multi_carrier or center_freq is None:
+            return
+        if not extra:
+            return
+        carrier = extra.get("carrier")
+        if carrier is None:
+            carrier = extra.get("channel")
+        if carrier is None:
+            return
+        freq_band = extra.get("freq_band", band_guess)
+        if freq_band is None:
+            return
+        freq_offset = extra.get("freq_offset", 0)
+        dl_freq = tetra_dl_carrier_hz(int(freq_band), int(carrier), int(freq_offset))
+        offset = dl_freq - center_freq
+        if abs(offset) > (sample_rate / 2 - 12_500):
+            return
+        if offset in offset_set:
+            return
+        offset_set.add(offset)
+        active_offsets.append(offset)
+        active_offsets = sorted(active_offsets, key=lambda x: abs(x))[: max(1, args.max_carriers)]
+
+    def process_chunk(samples: np.ndarray) -> None:
+        nonlocal frames_seen, voice_segments
+
+        offsets = list(active_offsets)
+        for offset in offsets:
+            demodulated = processor.process(samples, freq_offset=offset)
+            if demodulated is None or len(demodulated) < 255:
+                continue
+
+            frames = decoder.decode(demodulated, confidences=processor.symbol_confidence)
+            for frame in frames:
+                frames_seen += 1
+                info = frame.get("additional_info", {})
+                if "mcc" in info:
+                    mcc_counts[int(info["mcc"])] += 1
+                if "mnc" in info:
+                    mnc_counts[int(info["mnc"])] += 1
+
+                meta = frame.get("call_metadata", {})
+                if meta:
+                    call_type = meta.get("call_type")
+                    if (
+                        meta.get("talkgroup_id")
+                        and call_type == "Group"
+                        and frame.get("mac_pdu", {}).get("type") == "MAC_RESOURCE"
+                    ):
+                        group_counts[int(meta["talkgroup_id"])] += 1
+                    if meta.get("source_ssi"):
+                        issi_counts[int(meta["source_ssi"])] += 1
+                    if meta.get("dest_ssi"):
+                        issi_counts[int(meta["dest_ssi"])] += 1
+                    maybe_add_offset(meta)
+
+                extra = frame.get("mac_pdu_extra") or {}
+                if extra:
+                    maybe_add_offset(extra)
+
+                if voice.working:
+                    codec_input = frame.get("codec_input")
+                    if codec_input is None and frame.get("position") is not None:
+                        codec_input = tch_assembler.add_burst(demodulated, frame.get("position"))
+                    if codec_input:
+                        audio = voice.decode_frame(codec_input)
+                        if audio.size > 0 and float(np.max(np.abs(audio))) > 1e-4:
+                            voice_segments += 1
+                            if args.save_audio:
+                                out_path = audio_dir / f"{iq_path.stem}_voice_{voice_segments:04d}.wav"
+                                audio_i16 = np.clip(audio * 32767.0, -32768, 32767).astype(np.int16)
+                                with wave.open(str(out_path), "wb") as out_wav:
+                                    out_wav.setnchannels(1)
+                                    out_wav.setsampwidth(2)
+                                    out_wav.setframerate(8000)
+                                    out_wav.writeframes(audio_i16.tobytes())
+
+    processed_frames += len(first_samples)
+    if max_frames is None or processed_frames <= max_frames:
+        process_chunk(first_samples)
+    for samples in sample_iter:
+        processed_frames += len(samples)
+        if max_frames is not None and processed_frames > max_frames:
+            break
+        process_chunk(samples)
+
+    print(f"[SUMMARY] Frames decoded: {frames_seen}")
+    if mcc_counts:
+        print(f"[SUMMARY] MCC counts: {dict(mcc_counts.most_common(5))}")
+    if mnc_counts:
+        print(f"[SUMMARY] MNC counts: {dict(mnc_counts.most_common(5))}")
+    if group_counts:
+        print(f"[SUMMARY] GSSI groups: {dict(group_counts.most_common(5))}")
+    if issi_counts:
+        print(f"[SUMMARY] ISSI users: {dict(issi_counts.most_common(5))}")
+    print(f"[SUMMARY] Voice segments: {voice_segments}")
+
+    if ref:
+        def _overlap(name: str, ref_set: set[int], counts: Counter[int]) -> None:
+            if not ref_set:
+                return
+            decoded = set(counts.keys())
+            overlap = ref_set & decoded
+            print(f"[COMPARE] {name}: decoded={len(decoded)} ref={len(ref_set)} overlap={len(overlap)}")
+
+        _overlap("MCC", ref["mcc"], mcc_counts)
+        _overlap("MNC", ref["mnc"], mnc_counts)
+        _overlap("Groups", ref["groups"], group_counts)
+        _overlap("ISSI", ref["issi"], issi_counts)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_tetra_codec.sh
+++ b/scripts/install_tetra_codec.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${1:-/tmp/tetra_codec_build}"
+OSMO_DIR="${BUILD_DIR}/osmo-tetra"
+ETSI_PATCH_DIR="${OSMO_DIR}/etsi_codec-patches"
+CODEC_DIR="${OSMO_DIR}/codec"
+CODEC_BIN_DIR="${ROOT_DIR}/tetraear/tetra_codec/bin"
+
+ETSI_URL="http://www.etsi.org/deliver/etsi_en/300300_300399/30039502/01.03.01_60/en_30039502v010301p0.zip"
+ETSI_MD5="a8115fe68ef8f8cc466f4192572a1e3e"
+ETSI_ZIP="${ETSI_PATCH_DIR}/etsi_tetra_codec.zip"
+
+mkdir -p "${BUILD_DIR}"
+
+if [ ! -d "${OSMO_DIR}" ]; then
+  git clone https://gitea.osmocom.org/tetra/osmo-tetra "${OSMO_DIR}"
+fi
+
+if [ ! -f "${ETSI_ZIP}" ]; then
+  if command -v curl >/dev/null 2>&1; then
+    curl -L "${ETSI_URL}" -o "${ETSI_ZIP}"
+  else
+    echo "curl is required to download ETSI codec (install curl or place ${ETSI_ZIP} manually)."
+    exit 1
+  fi
+fi
+
+if command -v md5sum >/dev/null 2>&1; then
+  MD5_ACTUAL="$(md5sum "${ETSI_ZIP}" | awk '{print $1}')"
+elif command -v md5 >/dev/null 2>&1; then
+  MD5_ACTUAL="$(md5 -q "${ETSI_ZIP}")"
+else
+  MD5_ACTUAL=""
+fi
+
+if [ -n "${MD5_ACTUAL}" ] && [ "${MD5_ACTUAL}" != "${ETSI_MD5}" ]; then
+  echo "ETSI codec MD5 mismatch: expected ${ETSI_MD5}, got ${MD5_ACTUAL}"
+  exit 1
+fi
+
+rm -rf "${CODEC_DIR}"
+mkdir -p "${CODEC_DIR}"
+unzip -L "${ETSI_ZIP}" -d "${CODEC_DIR}" >/dev/null
+
+while read -r patch_file; do
+  [ -z "${patch_file}" ] && continue
+  patch --batch -p1 -d "${CODEC_DIR}" < "${ETSI_PATCH_DIR}/${patch_file}"
+done < "${ETSI_PATCH_DIR}/series"
+
+make -C "${CODEC_DIR}/c-code"
+
+mkdir -p "${CODEC_BIN_DIR}"
+cp -f "${CODEC_DIR}/c-code/cdecoder" "${CODEC_DIR}/c-code/sdecoder" "${CODEC_BIN_DIR}/"
+
+echo "Installed codec binaries to ${CODEC_BIN_DIR}"

--- a/tetraear/__init__.py
+++ b/tetraear/__init__.py
@@ -17,7 +17,7 @@ Example:
     >>> processor = SignalProcessor()
 """
 
-__version__ = "2.2"
+__version__ = "2.3"
 __author__ = "TetraEar Team"
 __license__ = "MIT"
 

--- a/tetraear/audio/tch.py
+++ b/tetraear/audio/tch.py
@@ -1,0 +1,121 @@
+"""
+Traffic Channel (TCH) helpers for extracting codec input from TETRA bursts.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+
+from tetraear.core.lower_mac import build_cdecoder_block
+
+SYMBOLS_PER_SLOT = 255
+DATA_SYMBOLS_PER_BLOCK = 108
+TRAINING_SYMBOLS = 11
+BITS_PER_SYMBOL = 2
+
+
+def _dqpsk_symbols_from_complex(samples: np.ndarray) -> np.ndarray:
+    """Convert complex symbols to hard-decision π/4-DQPSK symbols (0-3)."""
+    if samples is None or len(samples) < 2:
+        return np.array([], dtype=np.uint8)
+
+    symbols = []
+    prev_sample = samples[0]
+    for sample in samples[1:]:
+        diff = sample * np.conj(prev_sample)
+        phase_diff = np.arctan2(np.imag(diff), np.real(diff))
+
+        if phase_diff < -5 * np.pi / 8:
+            symbol = 3
+        elif phase_diff < -3 * np.pi / 8:
+            symbol = 2
+        elif phase_diff < 3 * np.pi / 8:
+            symbol = 0
+        elif phase_diff < 5 * np.pi / 8:
+            symbol = 1
+        else:
+            symbol = 3
+
+        symbols.append(symbol)
+        prev_sample = sample
+
+    if not symbols:
+        return np.array([], dtype=np.uint8)
+
+    # Pad to preserve length; prepend last-known symbol for the first sample.
+    symbols.insert(0, symbols[0])
+    return np.array(symbols, dtype=np.uint8)
+
+
+def extract_tch_soft_bits(symbols: np.ndarray, start_bit: int) -> Optional[list[int]]:
+    """Extract 432 type-4 bits from a single TCH burst."""
+    if symbols is None or start_bit is None:
+        return None
+
+    if np.iscomplexobj(symbols):
+        symbols = _dqpsk_symbols_from_complex(symbols)
+
+    if symbols is None or len(symbols) < SYMBOLS_PER_SLOT:
+        return None
+
+    symbol_pos = int(start_bit) // BITS_PER_SYMBOL
+    if symbol_pos < 0 or symbol_pos + SYMBOLS_PER_SLOT > len(symbols):
+        return None
+
+    slot_symbols = np.asarray(symbols[symbol_pos : symbol_pos + SYMBOLS_PER_SLOT], dtype=np.int16)
+
+    soft_bits: list[int] = []
+
+    for i in range(DATA_SYMBOLS_PER_BLOCK):
+        sym = int(slot_symbols[i]) & 0x3
+        soft_bits.append((sym >> 1) & 1)
+        soft_bits.append(sym & 1)
+
+    second_start = DATA_SYMBOLS_PER_BLOCK + TRAINING_SYMBOLS
+    for i in range(second_start, second_start + DATA_SYMBOLS_PER_BLOCK):
+        if i >= len(slot_symbols):
+            break
+        sym = int(slot_symbols[i]) & 0x3
+        soft_bits.append((sym >> 1) & 1)
+        soft_bits.append(sym & 1)
+
+    if len(soft_bits) < 432:
+        return None
+    return soft_bits
+
+
+def pack_codec_input(soft_bits: list[int]) -> Optional[bytes]:
+    """Pack type-4 bits into ETSI codec input format."""
+    if soft_bits is None or len(soft_bits) < 432:
+        return None
+    bits = np.asarray(soft_bits[:432], dtype=np.uint8)
+    return build_cdecoder_block(bits)
+
+
+def extract_tch_codec_input(symbols: np.ndarray, start_bit: int) -> Optional[bytes]:
+    """Extract a single-burst codec input when enough soft bits are available."""
+    soft_bits = extract_tch_soft_bits(symbols, start_bit)
+    if not soft_bits:
+        return None
+    return pack_codec_input(soft_bits)
+
+
+class TchFrameAssembler:
+    """Assemble bursts into codec frames."""
+
+    def __init__(self, required_bits: int = 432):
+        self.required_bits = required_bits
+        self._buffer: list[int] = []
+
+    def add_burst(self, symbols: np.ndarray, start_bit: int) -> Optional[bytes]:
+        soft_bits = extract_tch_soft_bits(symbols, start_bit)
+        if not soft_bits:
+            return None
+        self._buffer.extend(soft_bits)
+        if len(self._buffer) < self.required_bits:
+            return None
+        frame_bits = self._buffer[: self.required_bits]
+        self._buffer = self._buffer[self.required_bits :]
+        return pack_codec_input(frame_bits)

--- a/tetraear/audio/voice.py
+++ b/tetraear/audio/voice.py
@@ -53,21 +53,49 @@ class VoiceProcessor:
         else:
             resolved_codec_dir = default_dir
 
-        self.cdecoder_path = Path(cdecoder_path or codec_path) if (cdecoder_path or codec_path) is not None else (resolved_codec_dir / "cdecoder.exe")
-        self.sdecoder_path = Path(sdecoder_path) if sdecoder_path is not None else (resolved_codec_dir / "sdecoder.exe")
+        def resolve_candidate(provided: str | os.PathLike[str] | None, candidates: list[str]) -> Path:
+            if provided is not None:
+                return Path(provided)
+            for name in candidates:
+                candidate = resolved_codec_dir / name
+                if candidate.exists():
+                    return candidate
+            return resolved_codec_dir / candidates[0]
 
-        self.channel_decoder_available = self.cdecoder_path.exists()
-        self.speech_decoder_available = self.sdecoder_path.exists()
+        self.cdecoder_path = resolve_candidate(cdecoder_path or codec_path, ["cdecoder", "cdecoder.exe"])
+        self.sdecoder_path = resolve_candidate(sdecoder_path, ["sdecoder", "sdecoder.exe"])
+
+        for path in (self.cdecoder_path, self.sdecoder_path):
+            if path.exists() and os.name != "nt":
+                try:
+                    if not os.access(path, os.X_OK):
+                        path.chmod(path.stat().st_mode | 0o111)
+                except Exception:
+                    pass
+
+        def is_windows_binary(path: Path) -> bool:
+            try:
+                with path.open("rb") as handle:
+                    return handle.read(2) == b"MZ"
+            except Exception:
+                return False
+
+        self.channel_decoder_available = self.cdecoder_path.exists() and os.access(self.cdecoder_path, os.X_OK)
+        self.speech_decoder_available = self.sdecoder_path.exists() and os.access(self.sdecoder_path, os.X_OK)
         self.working = self.channel_decoder_available and self.speech_decoder_available
 
         if not self.channel_decoder_available:
             logger.warning("TETRA codec channel decoder not found at %s", self.cdecoder_path)
         else:
+            if os.name != "nt" and is_windows_binary(self.cdecoder_path):
+                logger.warning("Windows codec detected at %s; install native codec or use Wine", self.cdecoder_path)
             logger.debug("TETRA codec channel decoder found at %s", self.cdecoder_path)
 
         if not self.speech_decoder_available:
             logger.warning("TETRA codec speech decoder not found at %s", self.sdecoder_path)
         else:
+            if os.name != "nt" and is_windows_binary(self.sdecoder_path):
+                logger.warning("Windows codec detected at %s; install native codec or use Wine", self.sdecoder_path)
             logger.debug("TETRA codec speech decoder found at %s", self.sdecoder_path)
             
     def decode_frame(self, frame_data: bytes) -> np.ndarray:

--- a/tetraear/core/decoder.py
+++ b/tetraear/core/decoder.py
@@ -9,6 +9,7 @@ from typing import Optional
 
 from tetraear.core.crypto import TEADecryptor, TetraKeyManager
 from tetraear.core.protocol import TetraProtocolParser, TetraBurst, MacPDU, CallMetadata
+from tetraear.core.lower_mac import BlockType, LowerMacDecoder, TrainSeq, detect_training_sequence
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class TetraDecoder:
         self.key_manager = key_manager
         self.auto_decrypt = auto_decrypt
         self.protocol_parser = TetraProtocolParser()  # Add protocol parser
+        self.lower_mac = LowerMacDecoder()
         self._setup_common_keys()
     
     def _setup_common_keys(self):
@@ -137,7 +139,7 @@ class TetraDecoder:
         
         logger.info(f"Loaded {len(self.user_keys)} user-provided encryption keys")
         
-    def symbols_to_bits(self, symbols):
+    def symbols_to_bits(self, symbols, *, swap_bits: bool = False):
         """
         Convert demodulated symbols to bits (2 bits per symbol).
         Handles both 0-7 (8-PSK) and 0-3 (π/4-DQPSK) input formats.
@@ -164,9 +166,46 @@ class TetraDecoder:
                 else: val = 0
             
             mapped_symbols.append(val)
-            bits.extend([val >> 1, val & 1])
+            if swap_bits:
+                bits.extend([val & 1, val >> 1])
+            else:
+                bits.extend([val >> 1, val & 1])
             
         return np.array(bits), np.array(mapped_symbols)
+
+    def _symbols_to_soft_bits(self, symbols: np.ndarray, confidences: np.ndarray, *, swap_bits: bool = False) -> np.ndarray:
+        """Convert symbols + confidence into soft bits."""
+        soft_bits: list[int] = []
+        max_symbol = np.max(symbols) if len(symbols) > 0 else 0
+        is_dqpsk = max_symbol <= 3
+
+        for idx, s in enumerate(symbols):
+            conf = float(confidences[idx]) if confidences is not None and idx < len(confidences) else 1.0
+            conf = max(0.0, min(conf, 1.0))
+            soft = int(1 + 126 * conf)
+            if is_dqpsk:
+                val = int(s) & 0x3
+            else:
+                if s in [0, 1, 2]:
+                    val = 0
+                elif s in [3, 4]:
+                    val = 1
+                elif s in [5]:
+                    val = 3
+                elif s in [6, 7]:
+                    val = 2
+                else:
+                    val = 0
+            if swap_bits:
+                bit0 = val & 1
+                bit1 = val >> 1
+            else:
+                bit0 = val >> 1
+                bit1 = val & 1
+            soft_bits.append(soft if bit0 == 0 else -soft)
+            soft_bits.append(soft if bit1 == 0 else -soft)
+
+        return np.array(soft_bits, dtype=np.int16)
     
     def find_sync(self, bits, threshold=0.85, return_max_corr=False):
         """
@@ -293,6 +332,47 @@ class TetraDecoder:
         if return_max_corr:
             return sync_positions, max_corr
         return sync_positions
+
+    def _sync_patterns_symbols(self, swap_bits: bool = False) -> list[np.ndarray]:
+        """Convert known sync patterns from bits to dibit symbols."""
+        patterns = []
+        for pattern in (self.protocol_parser.SYNC_CONTINUOUS_DOWNLINK, self.protocol_parser.SYNC_DISCONTINUOUS_DOWNLINK):
+            symbols = []
+            for i in range(0, len(pattern), 2):
+                if i + 1 >= len(pattern):
+                    break
+                if swap_bits:
+                    val = (pattern[i + 1] << 1) | pattern[i]
+                else:
+                    val = (pattern[i] << 1) | pattern[i + 1]
+                symbols.append(val)
+            if symbols:
+                patterns.append(np.array(symbols))
+        return patterns
+
+    def find_sync_symbols(self, symbols: np.ndarray, threshold: float = 0.8, swap_bits: bool = False):
+        """Find sync positions using symbol-level training sequences."""
+        if symbols is None or len(symbols) < 22:
+            return [], 0.0
+
+        patterns = self._sync_patterns_symbols(swap_bits=swap_bits)
+        if not patterns:
+            return [], 0.0
+
+        best_corr = 0.0
+        sync_positions = []
+        for pattern in patterns:
+            win = len(pattern)
+            if len(symbols) < win:
+                continue
+            for idx in range(0, len(symbols) - win + 1):
+                window = symbols[idx : idx + win]
+                match = float(np.sum(window == pattern)) / win
+                if match > best_corr:
+                    best_corr = match
+                if match >= threshold:
+                    sync_positions.append(idx * 2)  # convert to bit index
+        return sync_positions, best_corr
     
     def decode_frame(self, bits, start_pos, symbols=None):
         """
@@ -413,7 +493,7 @@ class TetraDecoder:
                 
                 # Parse MAC PDU even if CRC failed (may still be partially valid)
                 try:
-                    mac_pdu = self.protocol_parser.parse_mac_pdu(burst.data_bits)
+                    mac_pdu = self.protocol_parser.parse_mac_pdu(burst.data_bits, crc_ok=burst.crc_ok)
                     
                     if mac_pdu:
                         frame_data['mac_pdu'] = {
@@ -832,60 +912,133 @@ class TetraDecoder:
         
         return frame_data
     
-    def decode(self, symbols):
+    def decode(self, symbols, *, confidences: Optional[np.ndarray] = None):
         """
         Decode TETRA frames from symbol stream.
         """
-        # Convert symbols to bits and mapped symbols (0-3)
-        bits, mapped_symbols = self.symbols_to_bits(symbols)
-        
-        # Find synchronization patterns (Training Sequence)
-        # Use adaptive thresholding based on max correlation to avoid dropping frames
-        # The find_sync function now has built-in adaptive thresholding when max_corr is close to threshold
-        sync_positions, max_corr = self.find_sync(bits, threshold=0.90, return_max_corr=True)
-        
-        if not sync_positions:
-            # Try 0.85 threshold - find_sync will use adaptive threshold if max_corr is close
-            sync_positions, max_corr = self.find_sync(bits, threshold=0.85, return_max_corr=True)
-            if not sync_positions:
-                # Try 0.80 threshold - find_sync will use adaptive threshold if max_corr is close
-                sync_positions, max_corr = self.find_sync(bits, threshold=0.80, return_max_corr=True)
-                if not sync_positions and max_corr >= 0.75:
-                    # Last resort: use adaptive threshold based on max correlation
-                    adaptive_threshold = max(0.75, max_corr - 0.02)
-                    sync_positions, _ = self.find_sync(bits, threshold=adaptive_threshold, return_max_corr=True)
-                    # Do not go lower than 0.75 for 22-bit sync
-        
-        # Decode frames
-        frames = []
-        for pos in sync_positions:
-            # Adjust position to start of burst
-            # TS starts at bit 216 (symbol 108)
-            # But we need to be careful about array bounds
-            start_pos = pos - 216
-            
-            if start_pos >= 0:
-                # Extract symbols for this frame
-                # 255 symbols = 510 bits
-                start_sym = start_pos // 2
-                if start_sym + 255 <= len(mapped_symbols):
-                    frame_symbols = mapped_symbols[start_sym : start_sym + 255]
-                    
-                    # Reconstruct bits for decode_frame (it expects bits)
-                    # But decode_frame logic for header/type is based on bits
-                    # We pass the bits corresponding to the frame
-                    frame_bits = bits[start_pos : start_pos + 510]
-                    
-                    # Calculate a pseudo frame number based on position
-                    # Assuming continuous stream, 510 bits per timeslot
-                    current_frame_num = start_pos // 510
-                    
-                    frame = self.decode_frame(frame_bits, 0, frame_symbols, frame_number=current_frame_num)
-                    if frame:
-                        frames.append(frame)
-                        logger.info(f"Decoded frame {frame['number']} (type: {frame['type']})")
-        
+        if symbols is None or len(symbols) < 255:
+            return []
+
+        best_bits = None
+        best_symbols = None
+        best_score = -1
+        best_swap = False
+        best_rotation = 0
+
+        for rotation in range(4):
+            rotated = (symbols + rotation) % 4
+            for swap_bits in (False, True):
+                bits, mapped_symbols = self.symbols_to_bits(rotated, swap_bits=swap_bits)
+                score = self._score_training_sequences(bits)
+                if score > best_score:
+                    best_score = score
+                    best_bits = bits
+                    best_symbols = mapped_symbols
+                    best_swap = swap_bits
+                    best_rotation = rotation
+
+        if best_bits is None:
+            return []
+
+        bursts = self._extract_bursts(best_bits)
+        soft_bits = None
+        if confidences is not None and len(confidences) >= len(symbols):
+            rotated = (symbols + best_rotation) % 4
+            soft_bits = self._symbols_to_soft_bits(rotated, confidences, swap_bits=best_swap)
+        frames: list[dict] = []
+        frame_number = 0
+
+        for start_pos, train_seq in bursts:
+            burst_bits = best_bits[start_pos : start_pos + 510]
+            if soft_bits is not None and len(soft_bits) >= start_pos + 510:
+                burst_bits = soft_bits[start_pos : start_pos + 510]
+            blocks = self.lower_mac.decode_burst(burst_bits, train_seq)
+            if self.lower_mac.mcc is not None:
+                self.protocol_parser.mcc = self.lower_mac.mcc
+            if self.lower_mac.mnc is not None:
+                self.protocol_parser.mnc = self.lower_mac.mnc
+
+            for block in blocks:
+                frame_data = {
+                    "number": frame_number,
+                    "type": block.block_type.value,
+                    "type_name": block.block_type.value,
+                    "position": start_pos,
+                    "crc_ok": block.crc_ok,
+                    "scrambling_code": block.scrambling_code,
+                    "additional_info": {},
+                }
+                frame_number += 1
+
+                if block.type1_bits is not None:
+                    frame_data["bits"] = block.type1_bits.tolist()
+                if block.codec_input:
+                    frame_data["has_voice"] = True
+                    frame_data["codec_input"] = block.codec_input
+
+                if block.extra:
+                    frame_data["additional_info"].update(block.extra)
+                    if "mcc" in block.extra:
+                        frame_data["mcc"] = block.extra["mcc"]
+                    if "mnc" in block.extra:
+                        frame_data["mnc"] = block.extra["mnc"]
+
+                if block.type1_bits is not None and block.block_type in (BlockType.NDB, BlockType.SCH_F, BlockType.SB2):
+                    mac_pdu = self.protocol_parser.parse_mac_pdu(block.type1_bits, crc_ok=block.crc_ok)
+                    if mac_pdu:
+                        frame_data["mac_pdu"] = {
+                            "type": mac_pdu.pdu_type.name,
+                            "encrypted": mac_pdu.encrypted,
+                            "address": mac_pdu.address,
+                            "length": mac_pdu.length,
+                            "data": mac_pdu.data,
+                        }
+                        if mac_pdu.extra:
+                            frame_data["mac_pdu_extra"] = mac_pdu.extra
+                        frame_data["encrypted"] = mac_pdu.encrypted
+
+                        call_meta = self.protocol_parser.parse_call_metadata(mac_pdu)
+                        if call_meta:
+                            frame_data["call_metadata"] = {
+                                "call_type": call_meta.call_type,
+                                "talkgroup_id": call_meta.talkgroup_id,
+                                "source_ssi": call_meta.source_ssi,
+                                "dest_ssi": call_meta.dest_ssi,
+                                "channel": call_meta.channel_allocated,
+                                "encryption": call_meta.encryption_enabled,
+                                "encryption_alg": call_meta.encryption_algorithm,
+                                "mcc": call_meta.mcc,
+                                "mnc": call_meta.mnc,
+                            }
+
+                frames.append(frame_data)
+
         return frames
+
+    def _score_training_sequences(self, bits: np.ndarray) -> int:
+        matches = 0
+        idx = 0
+        max_len = min(len(bits), 510 * 12)
+        while idx + 510 <= max_len:
+            ts, corr = detect_training_sequence(bits, idx)
+            if ts != TrainSeq.UNKNOWN and corr >= 0.75:
+                matches += 1
+                idx += 510
+            else:
+                idx += 2
+        return matches
+
+    def _extract_bursts(self, bits: np.ndarray) -> list[tuple[int, TrainSeq]]:
+        bursts: list[tuple[int, TrainSeq]] = []
+        idx = 0
+        while idx + 510 <= len(bits):
+            ts, corr = detect_training_sequence(bits, idx)
+            if ts != TrainSeq.UNKNOWN and corr >= 0.75:
+                bursts.append((idx, ts))
+                idx += 510
+            else:
+                idx += 2
+        return bursts
 
     def decode_frame(self, bits, start_pos, symbols=None, frame_number=0):
         """
@@ -993,7 +1146,7 @@ class TetraDecoder:
                 
                 # Parse MAC PDU even if CRC failed (may still be partially valid)
                 try:
-                    mac_pdu = self.protocol_parser.parse_mac_pdu(burst.data_bits)
+                    mac_pdu = self.protocol_parser.parse_mac_pdu(burst.data_bits, crc_ok=burst.crc_ok)
                     
                     if mac_pdu:
                         frame_data['mac_pdu'] = {

--- a/tetraear/core/lower_mac.py
+++ b/tetraear/core/lower_mac.py
@@ -1,0 +1,530 @@
+"""
+Pure-Python lower MAC / FEC helpers ported from osmo-tetra.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+import numpy as np
+
+SCRAMB_INIT = 3
+TETRA_CRC_OK = 0x1D0F
+
+
+class BlockType(Enum):
+    SB1 = "SB1"
+    SB2 = "SB2"
+    NDB = "NDB"
+    SCH_HU = "SCH_HU"
+    SCH_F = "SCH_F"
+    BBK = "BBK"
+
+
+@dataclass
+class BlockParams:
+    type345_bits: int
+    type2_bits: int
+    type1_bits: int
+    interleave_a: int
+    have_crc16: bool
+
+
+BLOCK_PARAMS: dict[BlockType, BlockParams] = {
+    BlockType.SB1: BlockParams(type345_bits=120, type2_bits=80, type1_bits=60, interleave_a=11, have_crc16=True),
+    BlockType.SB2: BlockParams(type345_bits=216, type2_bits=144, type1_bits=124, interleave_a=101, have_crc16=True),
+    BlockType.NDB: BlockParams(type345_bits=216, type2_bits=144, type1_bits=124, interleave_a=101, have_crc16=True),
+    BlockType.SCH_HU: BlockParams(type345_bits=168, type2_bits=112, type1_bits=92, interleave_a=13, have_crc16=True),
+    BlockType.SCH_F: BlockParams(type345_bits=432, type2_bits=288, type1_bits=268, interleave_a=103, have_crc16=True),
+    BlockType.BBK: BlockParams(type345_bits=30, type2_bits=30, type1_bits=14, interleave_a=0, have_crc16=False),
+}
+
+
+@dataclass
+class LowerMacBlock:
+    block_type: BlockType
+    blk_num: int
+    type1_bits: Optional[np.ndarray]
+    crc_ok: bool
+    type4_bits: np.ndarray
+    scrambling_code: int
+    is_traffic: bool = False
+    codec_input: Optional[bytes] = None
+    extra: Optional[dict] = None
+
+
+# Burst layout constants (bits)
+DQPSK4_BITS_PER_SYM = 2
+
+SB_BLK1_OFFSET = (6 + 1 + 40) * DQPSK4_BITS_PER_SYM
+SB_BBK_OFFSET = (6 + 1 + 40 + 60 + 19) * DQPSK4_BITS_PER_SYM
+SB_BLK2_OFFSET = (6 + 1 + 40 + 60 + 19 + 15) * DQPSK4_BITS_PER_SYM
+
+SB_BLK1_BITS = 60 * DQPSK4_BITS_PER_SYM
+SB_BBK_BITS = 15 * DQPSK4_BITS_PER_SYM
+SB_BLK2_BITS = 108 * DQPSK4_BITS_PER_SYM
+
+NDB_BLK1_OFFSET = (5 + 1 + 1) * DQPSK4_BITS_PER_SYM
+NDB_BBK1_OFFSET = (5 + 1 + 1 + 108) * DQPSK4_BITS_PER_SYM
+NDB_BBK2_OFFSET = (5 + 1 + 1 + 108 + 7 + 11) * DQPSK4_BITS_PER_SYM
+NDB_BLK2_OFFSET = (5 + 1 + 1 + 108 + 7 + 11 + 8) * DQPSK4_BITS_PER_SYM
+
+NDB_BBK1_BITS = 7 * DQPSK4_BITS_PER_SYM
+NDB_BBK2_BITS = 8 * DQPSK4_BITS_PER_SYM
+NDB_BLK_BITS = 108 * DQPSK4_BITS_PER_SYM
+NDB_BBK_BITS = SB_BBK_BITS
+
+
+# Training sequences (from osmo-tetra tetra_burst.c)
+N_BITS = np.array(
+    [1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0],
+    dtype=np.uint8,
+)
+P_BITS = np.array(
+    [0, 1, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 0],
+    dtype=np.uint8,
+)
+Q_BITS = np.array(
+    [1, 0, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1],
+    dtype=np.uint8,
+)
+X_BITS = np.array(
+    [1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 0, 0, 1, 1],
+    dtype=np.uint8,
+)
+Y_BITS = np.array(
+    [1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1],
+    dtype=np.uint8,
+)
+
+
+class TrainSeq(Enum):
+    SYNC = "SYNC"
+    NORM_1 = "NORM_1"
+    NORM_2 = "NORM_2"
+    NORM_3 = "NORM_3"
+    EXT = "EXT"
+    UNKNOWN = "UNKNOWN"
+
+
+def bits_to_uint(bits: np.ndarray, start: int, length: int) -> int:
+    val = 0
+    end = start + length
+    for bit in bits[start:end]:
+        val = (val << 1) | (int(bit) & 1)
+    return val
+
+
+def crc16_ccitt_bits(bits: np.ndarray) -> int:
+    crc = 0xFFFF
+    for bit in bits:
+        crc ^= (int(bit) & 1) << 15
+        if crc & 0x8000:
+            crc = (crc << 1) ^ 0x1021
+        else:
+            crc <<= 1
+        crc &= 0xFFFF
+    return crc
+
+
+def _next_lfsr_bit(lfsr: int) -> tuple[int, int]:
+    bit = (
+        ((lfsr >> 0) ^ (lfsr >> 6) ^ (lfsr >> 9) ^ (lfsr >> 10) ^
+         (lfsr >> 16) ^ (lfsr >> 20) ^ (lfsr >> 21) ^ (lfsr >> 22) ^
+         (lfsr >> 24) ^ (lfsr >> 25) ^ (lfsr >> 27) ^ (lfsr >> 28) ^
+         (lfsr >> 30) ^ (lfsr >> 31)) & 1
+    )
+    lfsr = (lfsr >> 1) | (bit << 31)
+    return bit & 0xFF, lfsr
+
+
+def tetra_scramb_get_init(mcc: int, mnc: int, colour: int) -> int:
+    mcc &= 0x3FF
+    mnc &= 0x3FFF
+    colour &= 0x3F
+    scramb_init = colour | (mnc << 6) | (mcc << 20)
+    scramb_init = (scramb_init << 2) | SCRAMB_INIT
+    return scramb_init
+
+
+def tetra_scramb_bits(lfsr_init: int, bits: np.ndarray) -> np.ndarray:
+    lfsr = lfsr_init & 0xFFFFFFFF
+    out = np.array(bits, dtype=np.uint8, copy=True)
+    for idx in range(len(out)):
+        bit, lfsr = _next_lfsr_bit(lfsr)
+        out[idx] ^= bit
+    return out
+
+
+def tetra_scramb_soft(lfsr_init: int, bits: np.ndarray) -> np.ndarray:
+    lfsr = lfsr_init & 0xFFFFFFFF
+    out = np.array(bits, dtype=np.int16, copy=True)
+    for idx in range(len(out)):
+        bit, lfsr = _next_lfsr_bit(lfsr)
+        if bit:
+            out[idx] = -out[idx]
+    return out
+
+
+def block_deinterleave(k: int, a: int, data: np.ndarray) -> np.ndarray:
+    out = np.zeros(k, dtype=data.dtype)
+    for i in range(1, k + 1):
+        idx = 1 + (a * i) % k
+        out[i - 1] = data[idx - 1]
+    return out
+
+
+class _Puncturer:
+    def __init__(self, p: list[int], t: int, period: int, i_func):
+        self.p = p
+        self.t = t
+        self.period = period
+        self.i_func = i_func
+
+
+def _i_func_equals(j: int) -> int:
+    return j
+
+
+def _i_func_292(j: int) -> int:
+    return j + ((j - 1) // 65)
+
+
+def _i_func_148(j: int) -> int:
+    return j + ((j - 1) // 35)
+
+
+P_RATE2_3 = [0, 1, 2, 5]
+P_RATE1_3 = [0, 1, 2, 3, 5, 6, 7]
+P_RATE8_12 = [0, 1, 2, 4]
+P_RATE8_18 = [0, 1, 2, 3, 4, 5, 7, 8, 10, 11]
+P_RATE8_17 = [0, 1, 2, 3, 4, 5, 7, 8, 10, 11, 13, 14, 16, 17, 19, 20, 22, 23]
+
+PUNCTURERS = {
+    "2_3": _Puncturer(P_RATE2_3, t=3, period=8, i_func=_i_func_equals),
+    "1_3": _Puncturer(P_RATE1_3, t=6, period=8, i_func=_i_func_equals),
+    "292_432": _Puncturer(P_RATE2_3, t=3, period=8, i_func=_i_func_292),
+    "148_432": _Puncturer(P_RATE1_3, t=6, period=8, i_func=_i_func_148),
+    "112_168": _Puncturer(P_RATE8_12, t=3, period=6, i_func=_i_func_equals),
+    "72_162": _Puncturer(P_RATE8_18, t=9, period=12, i_func=_i_func_equals),
+    "38_80": _Puncturer(P_RATE8_17, t=17, period=24, i_func=_i_func_equals),
+}
+
+
+def tetra_rcpc_depunct(punct: str, data: np.ndarray, out_len: int) -> np.ndarray:
+    puncturer = PUNCTURERS[punct]
+    out = np.full(out_len, 0xFF, dtype=np.uint8)
+    t = puncturer.t
+    p = puncturer.p
+    for j in range(1, len(data) + 1):
+        i = puncturer.i_func(j)
+        k = puncturer.period * ((i - 1) // t) + p[i - t * ((i - 1) // t)]
+        if 0 < k <= out_len:
+            out[k - 1] = data[j - 1]
+    return out
+
+
+def tetra_rcpc_depunct_soft(punct: str, data: np.ndarray, out_len: int) -> np.ndarray:
+    puncturer = PUNCTURERS[punct]
+    out = np.zeros(out_len, dtype=np.int16)
+    t = puncturer.t
+    p = puncturer.p
+    for j in range(1, len(data) + 1):
+        i = puncturer.i_func(j)
+        k = puncturer.period * ((i - 1) // t) + p[i - t * ((i - 1) // t)]
+        if 0 < k <= out_len:
+            out[k - 1] = int(data[j - 1])
+    return out
+
+
+CONV_CCH_NEXT_OUTPUT = np.array([
+    [0, 15], [11, 4], [6, 9], [13, 2],
+    [5, 10], [14, 1], [3, 12], [8, 7],
+    [15, 0], [4, 11], [9, 6], [2, 13],
+    [10, 5], [1, 14], [12, 3], [7, 8],
+], dtype=np.uint8)
+
+CONV_CCH_NEXT_STATE = np.array([
+    [0, 1], [2, 3], [4, 5], [6, 7],
+    [8, 9], [10, 11], [12, 13], [14, 15],
+    [0, 1], [2, 3], [4, 5], [6, 7],
+    [8, 9], [10, 11], [12, 13], [14, 15],
+], dtype=np.uint8)
+
+CONV_TCH_NEXT_OUTPUT = np.array([
+    [0, 7], [6, 1], [5, 2], [3, 4],
+    [6, 1], [0, 7], [3, 4], [5, 2],
+    [7, 0], [1, 6], [2, 5], [4, 3],
+    [1, 6], [7, 0], [4, 3], [2, 5],
+], dtype=np.uint8)
+
+CONV_TCH_NEXT_STATE = np.array([
+    [0, 1], [2, 3], [4, 5], [6, 7],
+    [8, 9], [10, 11], [12, 13], [14, 15],
+    [0, 1], [2, 3], [4, 5], [6, 7],
+    [8, 9], [10, 11], [12, 13], [14, 15],
+], dtype=np.uint8)
+
+
+def _viterbi_decode(
+    next_state: np.ndarray,
+    next_output: np.ndarray,
+    soft: np.ndarray,
+    n_bits: int,
+    output_order: list[int],
+) -> np.ndarray:
+    n_states = next_state.shape[0]
+    metrics = np.full(n_states, -1e9, dtype=np.float64)
+    metrics[0] = 0.0
+    decisions_state = np.zeros((n_bits, n_states), dtype=np.int16)
+    decisions_bit = np.zeros((n_bits, n_states), dtype=np.uint8)
+    num_out = len(output_order)
+
+    for t in range(n_bits):
+        new_metrics = np.full(n_states, -1e9, dtype=np.float64)
+        soft_slice = soft[t * num_out : t * num_out + num_out]
+        for state in range(n_states):
+            prev_metric = metrics[state]
+            if prev_metric <= -1e8:
+                continue
+            for bit in (0, 1):
+                ns = int(next_state[state, bit])
+                out_sym = int(next_output[state, bit])
+                metric = 0.0
+                for k, out_idx in enumerate(output_order):
+                    s = int(soft_slice[k])
+                    if s == 0:
+                        continue
+                    expected = (out_sym >> out_idx) & 1
+                    metric += s if expected == 0 else -s
+                metric += prev_metric
+                if metric > new_metrics[ns]:
+                    new_metrics[ns] = metric
+                    decisions_state[t, ns] = state
+                    decisions_bit[t, ns] = bit
+        metrics = new_metrics
+
+    state = int(np.argmax(metrics))
+    out_bits = np.zeros(n_bits, dtype=np.uint8)
+    for t in range(n_bits - 1, -1, -1):
+        bit = decisions_bit[t, state]
+        out_bits[t] = bit
+        state = int(decisions_state[t, state])
+    return out_bits
+
+
+def viterbi_decode_cch(type3dp: np.ndarray, sym_count: int) -> np.ndarray:
+    if type3dp.dtype != np.uint8 or np.any((type3dp != 0) & (type3dp != 1) & (type3dp != 0xFF)):
+        soft = type3dp.astype(np.int16, copy=False)
+    else:
+        soft = np.zeros(sym_count * 4, dtype=np.int16)
+        for i in range(sym_count * 4):
+            val = int(type3dp[i])
+            if val == 0xFF:
+                soft[i] = 0
+            elif val == 0:
+                soft[i] = 127
+            else:
+                soft[i] = -127
+    return _viterbi_decode(CONV_CCH_NEXT_STATE, CONV_CCH_NEXT_OUTPUT, soft, sym_count, [3, 2, 1, 0])
+
+
+def viterbi_decode_tch(type3dp: np.ndarray, sym_count: int) -> np.ndarray:
+    soft = np.zeros(sym_count * 3, dtype=np.int16)
+    for i in range(sym_count * 3):
+        val = int(type3dp[i])
+        if val == 0xFF:
+            soft[i] = 0
+        elif val == 0:
+            soft[i] = 127
+        else:
+            soft[i] = -127
+    return _viterbi_decode(CONV_TCH_NEXT_STATE, CONV_TCH_NEXT_OUTPUT, soft, sym_count, [2, 1, 0])
+
+
+def detect_training_sequence(bits: np.ndarray, start: int = 0) -> tuple[TrainSeq, float]:
+    """Detect training sequence type in a burst."""
+    if len(bits) < start + 510:
+        return TrainSeq.UNKNOWN, 0.0
+    sync_window = bits[start + 214 : start + 214 + len(Y_BITS)]
+    sync_corr = float(np.mean(sync_window == Y_BITS)) if len(sync_window) == len(Y_BITS) else 0.0
+    norm_window = bits[start + 244 : start + 244 + len(N_BITS)]
+    if len(norm_window) != len(N_BITS):
+        return TrainSeq.UNKNOWN, 0.0
+
+    n_corr = float(np.mean(norm_window == N_BITS))
+    p_corr = float(np.mean(norm_window == P_BITS))
+    q_corr = float(np.mean(norm_window == Q_BITS))
+    best_norm = max(n_corr, p_corr, q_corr)
+
+    if sync_corr >= 0.75 and sync_corr >= best_norm:
+        return TrainSeq.SYNC, sync_corr
+    if best_norm >= 0.8:
+        if n_corr >= p_corr and n_corr >= q_corr:
+            return TrainSeq.NORM_1, n_corr
+        if p_corr >= q_corr:
+            return TrainSeq.NORM_2, p_corr
+        return TrainSeq.NORM_3, q_corr
+    return TrainSeq.UNKNOWN, max(sync_corr, best_norm)
+
+
+def build_cdecoder_block(type4_bits: np.ndarray) -> Optional[bytes]:
+    """Build ETSI TCH cdecoder input block (690 shorts) from 432 type-4 bits."""
+    if type4_bits is None or len(type4_bits) < 432:
+        return None
+    soft = np.any((type4_bits != 0) & (type4_bits != 1))
+    block = np.zeros(690, dtype=np.int16)
+    for i in range(6):
+        block[115 * i] = 0x6B21 + i
+    for i in range(114):
+        bit0 = type4_bits[i]
+        bit1 = type4_bits[114 + i]
+        bit2 = type4_bits[228 + i]
+        block[1 + i] = -127 if (bit0 < 0 if soft else bit0) else 127
+        block[116 + i] = -127 if (bit1 < 0 if soft else bit1) else 127
+        block[231 + i] = -127 if (bit2 < 0 if soft else bit2) else 127
+    for i in range(90):
+        bit3 = type4_bits[342 + i]
+        block[346 + i] = -127 if (bit3 < 0 if soft else bit3) else 127
+    return block.tobytes()
+
+
+def decode_access_assign(bits: np.ndarray) -> Optional[int]:
+    """Decode AACH Access-Assign to get DL usage marker."""
+    if bits is None or len(bits) < 14:
+        return None
+    if np.any((bits != 0) & (bits != 1)):
+        bits = np.array(bits < 0, dtype=np.uint8)
+    hdr = bits_to_uint(bits, 0, 2)
+    field1 = bits_to_uint(bits, 2, 6)
+    field2 = bits_to_uint(bits, 8, 6)
+    if hdr == 0:
+        return None
+    if hdr == 1:
+        return field1
+    if hdr in (2, 3):
+        return field1
+    return None
+
+
+class LowerMacDecoder:
+    def __init__(self) -> None:
+        self.mcc: Optional[int] = None
+        self.mnc: Optional[int] = None
+        self.colour_code: Optional[int] = None
+        self.scramb_init: Optional[int] = None
+
+    def _decode_block(self, block_type: BlockType, bits: np.ndarray, *, force_scramb: Optional[int] = None) -> LowerMacBlock:
+        params = BLOCK_PARAMS[block_type]
+        type5 = np.array(bits[: params.type345_bits], copy=True)
+        is_soft = np.any((type5 != 0) & (type5 != 1))
+        if force_scramb is not None:
+            scramb_init = force_scramb
+        elif block_type == BlockType.SB1:
+            scramb_init = SCRAMB_INIT
+        else:
+            scramb_init = self.scramb_init
+
+        if scramb_init is None:
+            return LowerMacBlock(block_type, 0, None, False, type5, 0)
+
+        if is_soft:
+            type4 = tetra_scramb_soft(scramb_init, type5.astype(np.int16))
+        else:
+            type4 = tetra_scramb_bits(scramb_init, type5.astype(np.uint8))
+
+        if params.interleave_a:
+            type3 = block_deinterleave(params.type345_bits, params.interleave_a, type4)
+            if is_soft:
+                type3dp = tetra_rcpc_depunct_soft("2_3", type3, params.type2_bits * 4)
+            else:
+                type3dp = tetra_rcpc_depunct("2_3", type3.astype(np.uint8), params.type2_bits * 4)
+            type2 = viterbi_decode_cch(type3dp, params.type2_bits)
+        else:
+            type2 = type4[: params.type2_bits]
+
+        if params.have_crc16:
+            crc = crc16_ccitt_bits(type2[: params.type1_bits + 16])
+            crc_ok = crc == TETRA_CRC_OK
+        else:
+            crc_ok = True
+
+        type1 = type2[: params.type1_bits]
+        return LowerMacBlock(block_type, 0, type1, crc_ok, type4, scramb_init)
+
+    def decode_burst(self, bits: np.ndarray, train_seq: TrainSeq) -> list[LowerMacBlock]:
+        blocks: list[LowerMacBlock] = []
+        bits = np.array(bits, copy=False)
+        if np.any((bits != 0) & (bits != 1)):
+            bits = bits.astype(np.int16, copy=False)
+        else:
+            bits = bits.astype(np.uint8, copy=False)
+
+        if train_seq == TrainSeq.SYNC:
+            sb1 = self._decode_block(BlockType.SB1, bits[SB_BLK1_OFFSET : SB_BLK1_OFFSET + SB_BLK1_BITS])
+            blocks.append(sb1)
+            if sb1.type1_bits is not None and sb1.crc_ok:
+                colour = bits_to_uint(sb1.type1_bits, 4, 6)
+                mcc = bits_to_uint(sb1.type1_bits, 31, 10)
+                mnc = bits_to_uint(sb1.type1_bits, 41, 14)
+                self.colour_code = colour
+                self.mcc = mcc
+                self.mnc = mnc
+                self.scramb_init = tetra_scramb_get_init(mcc, mnc, colour)
+                sb1.extra = {
+                    "colour_code": colour,
+                    "mcc": mcc,
+                    "mnc": mnc,
+                }
+
+            bbk_bits = bits[SB_BBK_OFFSET : SB_BBK_OFFSET + SB_BBK_BITS]
+            bbk = self._decode_block(BlockType.BBK, bbk_bits)
+            blocks.append(bbk)
+
+            sb2 = self._decode_block(BlockType.SB2, bits[SB_BLK2_OFFSET : SB_BLK2_OFFSET + SB_BLK2_BITS])
+            blocks.append(sb2)
+            return blocks
+
+        if train_seq in (TrainSeq.NORM_1, TrainSeq.NORM_2):
+            bbk_bits = np.concatenate(
+                [
+                    bits[NDB_BBK1_OFFSET : NDB_BBK1_OFFSET + NDB_BBK1_BITS],
+                    bits[NDB_BBK2_OFFSET : NDB_BBK2_OFFSET + NDB_BBK2_BITS],
+                ]
+            )
+            bbk = self._decode_block(BlockType.BBK, bbk_bits)
+            dl_usage = decode_access_assign(bbk.type1_bits if bbk.type1_bits is not None else bbk.type4_bits)
+            is_traffic = bool(dl_usage is not None and dl_usage > 3)
+            bbk.is_traffic = is_traffic
+            bbk.extra = {"dl_usage": dl_usage} if dl_usage is not None else None
+            blocks.append(bbk)
+
+            if train_seq == TrainSeq.NORM_2:
+                blk1_bits = bits[NDB_BLK1_OFFSET : NDB_BLK1_OFFSET + NDB_BLK_BITS]
+                blk2_bits = bits[NDB_BLK2_OFFSET : NDB_BLK2_OFFSET + NDB_BLK_BITS]
+                blk1 = self._decode_block(BlockType.NDB, blk1_bits)
+                blk1.blk_num = 1
+                blk1.is_traffic = is_traffic
+                blk2 = self._decode_block(BlockType.NDB, blk2_bits)
+                blk2.blk_num = 2
+                blk2.is_traffic = is_traffic
+                blocks.extend([blk1, blk2])
+                return blocks
+
+            # Train seq NORM_1 -> SCH/F combined blocks
+            combined = np.concatenate(
+                [
+                    bits[NDB_BLK1_OFFSET : NDB_BLK1_OFFSET + NDB_BLK_BITS],
+                    bits[NDB_BLK2_OFFSET : NDB_BLK2_OFFSET + NDB_BLK_BITS],
+                ]
+            )
+            schf = self._decode_block(BlockType.SCH_F, combined)
+            schf.is_traffic = is_traffic
+            if is_traffic:
+                schf.codec_input = build_cdecoder_block(schf.type4_bits)
+            blocks.append(schf)
+            return blocks
+
+        return blocks

--- a/tetraear/core/protocol.py
+++ b/tetraear/core/protocol.py
@@ -27,8 +27,13 @@ import logging
 from typing import Optional, Dict, List, Tuple
 from dataclasses import dataclass
 from enum import Enum
+from collections import Counter
 
 logger = logging.getLogger(__name__)
+
+
+MACPDU_LEN_2ND_STOLEN = -2
+MACPDU_LEN_START_FRAG = -1
 
 
 class BurstType(Enum):
@@ -117,9 +122,13 @@ class MacPDU:
     address: Optional[int]
     length: int
     data: bytes
+    data_bits: Optional[np.ndarray] = None
+    tm_sdu_bits: Optional[np.ndarray] = None
     fill_bits: int = 0
     encryption_mode: int = 0  # 0=Clear, 1=Class2, 2=Class3, 3=Reserved
     reassembled_data: Optional[bytes] = None  # For fragmented messages
+    crc_ok: Optional[bool] = None
+    extra: Optional[dict] = None
     
 
 @dataclass
@@ -188,6 +197,27 @@ class TetraProtocolParser:
         # Fragmentation handling
         self.fragment_buffer = bytearray()
         self.fragment_metadata = {}
+        self._network_votes: Counter[tuple[int, int, int]] = Counter()
+        self._llc_defrag: Dict[int, Dict[str, object]] = {}
+        self._mac_frag_active = False
+        self._mac_frag_bits: Optional[np.ndarray] = None
+        self._mac_frag_extra: Dict[str, object] = {}
+        self._ssi_votes: Counter[int] = Counter()
+
+    def _record_network_candidate(self, mcc: int, mnc: int, colour_code: int, *, strong: bool) -> None:
+        """Record MCC/MNC candidates and only lock in after repeats unless strong."""
+        if strong:
+            self.mcc = mcc
+            self.mnc = mnc
+            self.colour_code = colour_code
+            return
+
+        key = (mcc, mnc, colour_code)
+        self._network_votes[key] += 1
+        if self._network_votes[key] >= 3:
+            self.mcc = mcc
+            self.mnc = mnc
+            self.colour_code = colour_code
         
     def parse_burst(self, symbols: np.ndarray, slot_number: int = 0) -> Optional[TetraBurst]:
         """
@@ -266,24 +296,30 @@ class TetraProtocolParser:
     
     def _extract_training_sequence(self, bits: np.ndarray, burst_type: BurstType) -> np.ndarray:
         """Extract training sequence from burst."""
-        # Training sequence is typically in the middle of the burst
+        # Training sequence is typically in the middle of the burst.
+        # Use 11 symbols (22 bits) for normal/sync bursts based on TS length.
+        training_len_bits = 22
         if burst_type == BurstType.Synchronization:
-            # Sync burst: training at position ~108
-            return bits[108:130]
+            # Sync burst: training at position ~108 symbols -> 216 bits
+            start = 216
         else:
-            # Normal burst: training at position ~108
-            return bits[108:122]
+            # Normal burst: training at position ~108 symbols -> 216 bits
+            start = 216
+        end = min(len(bits), start + training_len_bits)
+        return bits[start:end]
     
     def _extract_data_bits(self, bits: np.ndarray, burst_type: BurstType) -> np.ndarray:
         """Extract data bits from burst (excluding training and tail)."""
-        # Normal burst: 216 bits (2 x 108) excluding training sequence
+        # Normal burst: 432 bits (2 x 108 symbols) excluding training sequence
         if burst_type == BurstType.NormalDownlink or burst_type == BurstType.NormalUplink:
-            # First block: bits 0-107
-            # Training: bits 108-121
-            # Second block: bits 122-229
-            # Tail: bits 230+
-            first_block = bits[0:108]
-            second_block = bits[122:230]
+            # First block: 108 symbols = 216 bits
+            # Training: 11 symbols = 22 bits
+            # Second block: 108 symbols = 216 bits
+            first_end = 108 * 2
+            training_end = first_end + 11 * 2
+            second_end = training_end + 108 * 2
+            first_block = bits[0:first_end]
+            second_block = bits[training_end:second_end]
             return np.concatenate([first_block, second_block])
         
         # For other burst types, return all bits
@@ -346,29 +382,163 @@ class TetraProtocolParser:
         crc_bits = [(crc >> i) & 1 for i in range(15, -1, -1)]
         return np.array(crc_bits)
     
-    def parse_mac_pdu(self, bits: np.ndarray) -> Optional[MacPDU]:
+    def parse_mac_pdu(self, bits: np.ndarray, *, crc_ok: Optional[bool] = None) -> Optional[MacPDU]:
         """
         Parse MAC layer PDU.
         Handles fragmentation (MAC-RESOURCE, MAC-FRAG, MAC-END).
         
         Args:
             bits: Data bits from burst
+            crc_ok: Optional CRC validity for the burst carrying this PDU
             
         Returns:
             Parsed MacPDU or None
         """
-        if len(bits) < 8:
+        if bits is None or len(bits) < 8:
             return None
-        
-        # MAC PDU Type (first 2 bits for Downlink)
-        # 00: MAC-RESOURCE
-        # 01: MAC-FRAG
-        # 10: MAC-BROADCAST
-        # 11: MAC-ENCRYPTED (or other, depending on context)
-        
-        pdu_type_int = (bits[0] << 1) | bits[1]
-        
-        # Map to internal Enum
+
+        if not isinstance(bits, np.ndarray):
+            bits = np.array(bits, dtype=np.int16)
+        else:
+            bits = bits.astype(np.int16, copy=False)
+
+        if np.any((bits != 0) & (bits != 1)):
+            bits = (bits < 0).astype(np.uint8)
+        else:
+            bits = bits.astype(np.uint8, copy=False)
+
+        def _bits_to_uint(bit_arr: np.ndarray, start: int, length: int) -> int:
+            val = 0
+            end = min(start + length, len(bit_arr))
+            for bit in bit_arr[start:end]:
+                val = (val << 1) | (int(bit) & 1)
+            return val
+
+        def _bits_to_bytes(bit_arr: np.ndarray) -> bytes:
+            if bit_arr is None or len(bit_arr) == 0:
+                return b""
+            out = bytearray()
+            for i in range(0, len(bit_arr), 8):
+                chunk = bit_arr[i : i + 8]
+                if len(chunk) < 8:
+                    chunk = np.pad(chunk, (0, 8 - len(chunk)))
+                val = 0
+                for bit in chunk:
+                    val = (val << 1) | (int(bit) & 1)
+                out.append(val)
+            return bytes(out)
+
+        def _decode_length(length_ind: int) -> Optional[int]:
+            if length_ind in (0x00, 0x3B, 0x3C):
+                return None
+            if length_ind <= 0x12:
+                return length_ind
+            if length_ind <= 0x3A:
+                return 18 + (length_ind - 18)
+            if length_ind == 0x3E:
+                return MACPDU_LEN_2ND_STOLEN
+            if length_ind == 0x3F:
+                return MACPDU_LEN_START_FRAG
+            return None
+
+        def _get_num_fill_bits(bit_arr: np.ndarray, length: int) -> int:
+            for i in range(1, length + 1):
+                if bit_arr[length - i] == 1:
+                    return i
+            return 0
+
+        def _parse_chan_alloc(bit_arr: np.ndarray, start: int) -> tuple[dict, int]:
+            cur = start
+            info: dict = {}
+            if cur + 2 > len(bit_arr):
+                return info, 0
+            info["alloc_type"] = _bits_to_uint(bit_arr, cur, 2); cur += 2
+            if cur + 4 > len(bit_arr):
+                return info, cur - start
+            info["timeslot"] = _bits_to_uint(bit_arr, cur, 4); cur += 4
+            if cur + 2 > len(bit_arr):
+                return info, cur - start
+            info["ul_dl"] = _bits_to_uint(bit_arr, cur, 2); cur += 2
+            if cur + 1 > len(bit_arr):
+                return info, cur - start
+            info["clch_perm"] = int(bit_arr[cur]); cur += 1
+            if cur + 1 > len(bit_arr):
+                return info, cur - start
+            info["cell_chg"] = int(bit_arr[cur]); cur += 1
+            if cur + 12 > len(bit_arr):
+                return info, cur - start
+            info["carrier"] = _bits_to_uint(bit_arr, cur, 12); cur += 12
+
+            if cur >= len(bit_arr):
+                return info, cur - start
+            ext_carr_pres = int(bit_arr[cur]); cur += 1
+            info["ext_carr_pres"] = ext_carr_pres
+            if ext_carr_pres:
+                if cur + 4 > len(bit_arr):
+                    return info, cur - start
+                info["freq_band"] = _bits_to_uint(bit_arr, cur, 4); cur += 4
+                if cur + 2 > len(bit_arr):
+                    return info, cur - start
+                info["freq_offset"] = _bits_to_uint(bit_arr, cur, 2); cur += 2
+                if cur + 3 > len(bit_arr):
+                    return info, cur - start
+                info["duplex_spacing"] = _bits_to_uint(bit_arr, cur, 3); cur += 3
+                if cur + 1 > len(bit_arr):
+                    return info, cur - start
+                info["reverse_operation"] = int(bit_arr[cur]); cur += 1
+
+            if cur + 2 > len(bit_arr):
+                return info, cur - start
+            monit_pattern = _bits_to_uint(bit_arr, cur, 2); cur += 2
+            info["monit_pattern"] = monit_pattern
+            if monit_pattern == 0 and cur + 2 <= len(bit_arr):
+                info["monit_patt_f18"] = _bits_to_uint(bit_arr, cur, 2)
+                cur += 2
+
+            if info.get("ul_dl") == 0:
+                if cur + 2 > len(bit_arr):
+                    return info, cur - start
+                info["ul_dl_ass"] = _bits_to_uint(bit_arr, cur, 2); cur += 2
+                if cur + 3 > len(bit_arr):
+                    return info, cur - start
+                info["bandwidth"] = _bits_to_uint(bit_arr, cur, 3); cur += 3
+                if cur + 3 > len(bit_arr):
+                    return info, cur - start
+                info["modulation"] = _bits_to_uint(bit_arr, cur, 3); cur += 3
+                if cur + 3 > len(bit_arr):
+                    return info, cur - start
+                info["max_ul_qam"] = _bits_to_uint(bit_arr, cur, 3); cur += 3
+                cur += 3  # reserved
+                if cur + 3 > len(bit_arr):
+                    return info, cur - start
+                info["conf_chan_stat"] = _bits_to_uint(bit_arr, cur, 3); cur += 3
+                if cur + 4 > len(bit_arr):
+                    return info, cur - start
+                info["bs_imbalance"] = _bits_to_uint(bit_arr, cur, 4); cur += 4
+                if cur + 5 > len(bit_arr):
+                    return info, cur - start
+                info["bs_tx_rel"] = _bits_to_uint(bit_arr, cur, 5); cur += 5
+                if cur + 2 > len(bit_arr):
+                    return info, cur - start
+                napping = _bits_to_uint(bit_arr, cur, 2); cur += 2
+                info["napping_sts"] = napping
+                if napping == 1:
+                    cur += 11
+                cur += 4
+                if cur < len(bit_arr):
+                    if bit_arr[cur]:
+                        cur += 1 + 16
+                    else:
+                        cur += 1
+                if cur < len(bit_arr):
+                    if bit_arr[cur]:
+                        cur += 1 + 16
+                    else:
+                        cur += 1
+                cur += 1
+            return info, cur - start
+
+        pdu_type_int = _bits_to_uint(bits, 0, 2)
         if pdu_type_int == 0:
             pdu_type = PDUType.MAC_RESOURCE
         elif pdu_type_int == 1:
@@ -376,224 +546,713 @@ class TetraProtocolParser:
         elif pdu_type_int == 2:
             pdu_type = PDUType.MAC_BROADCAST
         else:
-            # Type 3 is often MAC-END or MAC-U-SIGNAL depending on context/uplink/downlink
-            # For Downlink, 11 is often reserved or proprietary, or MAC-D-BLCK
-            # Let's assume MAC-END for now if it fits the structure
-            pdu_type = PDUType.MAC_END
+            pdu_type = PDUType.MAC_SUPPL
 
-        # Encryption Mode (Bits 2-3)
-        # 00: Class 1 (Clear)
-        # 01: Class 2 (SCK)
-        # 10: Class 3 (DCK)
-        # 11: Reserved
-        encryption_mode_val = (bits[2] << 1) | bits[3]
-        encrypted = encryption_mode_val > 0
-        
-        # Default fields
+        encrypted = False
         address = None
         length = 0
-        data_bytes = b''
-        fill_bit_ind = 0
-        
-        # Parse based on PDU Type
+        data_bytes = b""
+        data_bits = None
+        tm_sdu_bits = None
+        extra: dict = {}
+
+        addr_len_by_type = {
+            1: 24,
+            2: 10,
+            3: 24,
+            4: 24,
+            5: 34,
+            6: 30,
+            7: 34,
+        }
+
         if pdu_type == PDUType.MAC_RESOURCE:
-            # MAC-RESOURCE
-            # Bits: Type(2), EncMode(2), Fill(1), ...
-            fill_bit_ind = bits[4]
-            
-            # Position pointer
-            pos = 5
-            
-            # Encryption (already parsed mode)
-            
-            # Address (24 bits)
-            if len(bits) >= pos + 24:
-                address_bits = bits[pos:pos+24]
-                address = int(''.join(str(b) for b in address_bits), 2)
-                pos += 24
+            cur = 2
+            fill_bits = _bits_to_uint(bits, cur, 1); cur += 1
+            grant_position = _bits_to_uint(bits, cur, 1); cur += 1
+            encryption_mode = _bits_to_uint(bits, cur, 2); cur += 2
+            encrypted = encryption_mode > 0
+            rand_acc_flag = int(bits[cur]) if cur < len(bits) else 0; cur += 1
+            length_ind = _bits_to_uint(bits, cur, 6); cur += 6
+            addr_type = _bits_to_uint(bits, cur, 3); cur += 3
+
+            addr_len = addr_len_by_type.get(addr_type, 0)
+            usage_marker = None
+            if addr_len >= 24 and cur + 24 <= len(bits):
+                address = _bits_to_uint(bits, cur, 24)
+                if addr_type == 6 and cur + 30 <= len(bits):
+                    usage_marker = _bits_to_uint(bits, cur + 24, 6)
+            elif addr_len == 10 and cur + 10 <= len(bits):
+                address = _bits_to_uint(bits, cur, 10)
+            cur += addr_len
+
+            if cur < len(bits):
+                power_control_pres = int(bits[cur]); cur += 1
+                if power_control_pres:
+                    cur += 4
+            if cur < len(bits):
+                slot_granting_pres = int(bits[cur]); cur += 1
+                if slot_granting_pres:
+                    cur += 8
+            if cur < len(bits):
+                chan_alloc_pres = int(bits[cur]); cur += 1
+                if chan_alloc_pres:
+                    alloc_info, consumed = _parse_chan_alloc(bits, cur)
+                    if consumed:
+                        cur += consumed
+                        extra.update(alloc_info)
+
+            extra.update({
+                "fill_bits": fill_bits,
+                "grant_position": grant_position,
+                "rand_acc_flag": rand_acc_flag,
+                "encryption_mode": encryption_mode,
+                "length_ind": length_ind,
+                "addr_type": addr_type,
+                "usage_marker": usage_marker,
+            })
+            extra["address"] = address
+            if address is not None:
+                extra["ssi"] = address
+
+            mac_len = _decode_length(length_ind)
+            tm_sdu_len = None
+            if mac_len is not None and mac_len >= 0:
+                tm_sdu_len = mac_len * 8
+            elif mac_len == MACPDU_LEN_2ND_STOLEN:
+                extra["blk2_stolen"] = True
+            elif mac_len == MACPDU_LEN_START_FRAG:
+                extra["start_frag"] = True
+
+            if tm_sdu_len is not None:
+                end = min(len(bits), cur + tm_sdu_len)
             else:
-                return None # Truncated
-            
-            # Length (6 bits)
-            if len(bits) >= pos + 6:
-                length_bits = bits[pos:pos+6]
-                length = int(''.join(str(b) for b in length_bits), 2)
-                pos += 6
-            else:
-                return None # Truncated
-                
-            # Data
-            # If length is 0, it might mean "rest of slot" or specific rule
-            # Standard says: Length indicator 000000 means Null PDU or similar?
-            # Actually, length is in octets (bytes) usually.
-            
-            data_len_bits = length * 8
-            
-            # STRICT CHECK: Data length cannot exceed remaining bits significantly
-            if data_len_bits > len(bits) - pos + 16: # Allow small margin
-                return None
-            
-            if data_len_bits > 0 and len(bits) >= pos + data_len_bits:
-                data_bits = bits[pos:pos + data_len_bits]
-            else:
-                data_bits = bits[pos:]
-                
-            try:
-                data_bytes = BitArray(data_bits).tobytes()
-            except:
-                data_bytes = b''
-                
-            # Start fragmentation buffer
-            # Only start if this looks like the beginning of a message
-            self.fragment_buffer = bytearray(data_bytes)
-            self.fragment_metadata = {'address': address, 'encrypted': encrypted, 'mode': encryption_mode_val}
-            
-        elif pdu_type == PDUType.MAC_FRAG:
-            # MAC-FRAG
-            # Bits: Type(2), EncMode(2), Fill(1), ...
-            fill_bit_ind = bits[4]
-            pos = 5
-            
-            data_bits = bits[pos:]
-            try:
-                data_bytes = BitArray(data_bits).tobytes()
-            except:
-                data_bytes = b''
-                
-            # Append to buffer
-            self.fragment_buffer.extend(data_bytes)
-            
-            # Restore metadata
-            if self.fragment_metadata:
-                encrypted = self.fragment_metadata.get('encrypted', False)
-                address = self.fragment_metadata.get('address')
-            
-        elif pdu_type == PDUType.MAC_BROADCAST:
-            # MAC-BROADCAST
-            # Bits: Type(2), BroadcastType(2), ...
-            # BroadcastType: 00=SYSINFO, 01=ACCESS-DEFINE, ...
-            broadcast_type = (bits[2] << 1) | bits[3]
-            
-            pos = 4
-            # SYSINFO (Type 0)
-            if broadcast_type == 0:
-                # Parse SYSINFO elements
-                # MCC(10), MNC(14), CC(6), ...
-                if len(bits) >= pos + 30:
-                    self.mcc = int(''.join(str(b) for b in bits[pos:pos+10]), 2)
-                    self.mnc = int(''.join(str(b) for b in bits[pos+10:pos+24]), 2)
-                    self.colour_code = int(''.join(str(b) for b in bits[pos+24:pos+30]), 2)
-                    
-                    # STRICT CHECK: MCC/MNC sanity - Real TETRA networks
-                    # MCC must be 200-799 (valid ITU-T E.212 range)
-                    if self.mcc < 200 or self.mcc > 799:
-                        logger.debug(f"Invalid MCC {self.mcc} in SYNC - not real TETRA")
-                        return None
-                    if self.mnc > 999:
-                        logger.debug(f"Invalid MNC {self.mnc} in SYNC - not real TETRA")
-                        return None
-                    
-                    logger.info(f"Valid TETRA SYNC: MCC={self.mcc} MNC={self.mnc}")
+                end = len(bits)
+                if fill_bits and end > 0:
+                    end = max(cur, end - _get_num_fill_bits(bits[:end], end))
+
+            tm_sdu_bits = bits[cur:end] if end > cur else None
+            if mac_len == MACPDU_LEN_START_FRAG:
+                self._mac_frag_active = True
+                if tm_sdu_bits is not None and len(tm_sdu_bits) > 0:
+                    self._mac_frag_bits = np.array(tm_sdu_bits, copy=True)
                 else:
-                    return None
-            
-            data_bits = bits[pos:]
-            try:
-                data_bytes = BitArray(data_bits).tobytes()
-            except:
-                data_bytes = b''
-                
+                    self._mac_frag_bits = np.array([], dtype=np.uint8)
+                self._mac_frag_extra = {"address": address, **extra}
+                tm_sdu_bits = None
+            data_bits = tm_sdu_bits
+            data_bytes = _bits_to_bytes(data_bits)
+            length = len(data_bytes)
+            self.fragment_buffer = bytearray(data_bytes)
+            self.fragment_metadata = {"address": address, "encrypted": encrypted}
+            extra["tm_sdu_bits"] = tm_sdu_bits
+
+        elif pdu_type == PDUType.MAC_BROADCAST:
+            broadcast_type = _bits_to_uint(bits, 2, 2)
+            extra["broadcast_type"] = broadcast_type
+            data_bits = bits[4:]
+            data_bytes = _bits_to_bytes(data_bits)
+            length = len(data_bytes)
+
+        elif pdu_type == PDUType.MAC_FRAG:
+            frag_end_flag = _bits_to_uint(bits, 2, 1)
+            fillbits_present = _bits_to_uint(bits, 3, 1)
+            cur = 4
+
+            if frag_end_flag == 0:
+                # MAC-FRAG continuation
+                end = len(bits)
+                if fillbits_present and end > 0:
+                    end = max(cur, end - _get_num_fill_bits(bits[:end], end))
+                frag_bits = bits[cur:end] if end > cur else None
+                if frag_bits is not None and len(frag_bits) > 0:
+                    if not self._mac_frag_active:
+                        self._mac_frag_active = True
+                        self._mac_frag_bits = np.array(frag_bits, copy=True)
+                    elif self._mac_frag_bits is None or np.size(self._mac_frag_bits) == 0:
+                        self._mac_frag_bits = np.array(frag_bits, copy=True)
+                    else:
+                        self._mac_frag_bits = np.concatenate([self._mac_frag_bits, frag_bits])
+                extra.update({"frag_end": False, "fill_bits": fillbits_present})
+                tm_sdu_bits = None
+                data_bits = frag_bits
+                data_bytes = _bits_to_bytes(frag_bits) if frag_bits is not None else b""
+                length = len(data_bytes)
+            else:
+                # MAC-END, includes length indicator and optional chan alloc
+                position_of_grant = _bits_to_uint(bits, cur, 1); cur += 1
+                length_ind = _bits_to_uint(bits, cur, 6); cur += 6
+                slot_granting = _bits_to_uint(bits, cur, 1); cur += 1
+                if slot_granting and cur + 8 <= len(bits):
+                    cur += 8
+                chan_alloc_pres = _bits_to_uint(bits, cur, 1) if cur < len(bits) else 0
+                cur += 1 if cur < len(bits) else 0
+                if chan_alloc_pres:
+                    alloc_info, consumed = _parse_chan_alloc(bits, cur)
+                    if consumed:
+                        cur += consumed
+                        extra.update(alloc_info)
+
+                tm_sdu_len = length_ind * 8 if length_ind else None
+                end = len(bits)
+                if tm_sdu_len is not None and tm_sdu_len > 0:
+                    end = min(end, cur + tm_sdu_len)
+                if fillbits_present and end > 0:
+                    end = max(cur, end - _get_num_fill_bits(bits[:end], end))
+                frag_bits = bits[cur:end] if end > cur else None
+
+                if self._mac_frag_active and self._mac_frag_bits is not None and frag_bits is not None:
+                    tm_sdu_bits = np.concatenate([self._mac_frag_bits, frag_bits])
+                    self._mac_frag_active = False
+                    self._mac_frag_bits = None
+                    if self._mac_frag_extra:
+                        if address is None:
+                            address = self._mac_frag_extra.get("address")
+                        extra = {**self._mac_frag_extra, **extra}
+                        self._mac_frag_extra = {}
+                else:
+                    tm_sdu_bits = frag_bits
+
+                data_bits = tm_sdu_bits
+                data_bytes = _bits_to_bytes(data_bits) if data_bits is not None else b""
+                length = len(data_bytes)
+                extra.update({
+                    "frag_end": True,
+                    "fill_bits": fillbits_present,
+                    "position_of_grant": position_of_grant,
+                    "length_ind": length_ind,
+                    "slot_granting": slot_granting,
+                })
+
         else:
-            # Fallback / MAC-END
-            # Bits: Type(2), EncMode(2), Fill(1), Length(6)?
-            # MAC-END usually has structure: Type(2), EncMode(2), Fill(1), Length(6)
-            fill_bit_ind = bits[4]
-            pos = 5
-            
-            # Assuming Length is present for MAC-END
-            if len(bits) >= pos + 6:
-                length_bits = bits[pos:pos+6]
-                length = int(''.join(str(b) for b in length_bits), 2)
-                pos += 6
-            else:
-                # If no length field, treat as invalid for MAC-END
-                return None
-                
-            data_len_bits = length * 8
-            
-            # STRICT CHECK
-            if data_len_bits > len(bits) - pos + 16:
-                return None
-                
-            if data_len_bits > 0 and len(bits) >= pos + data_len_bits:
-                data_bits = bits[pos:pos + data_len_bits]
-            else:
-                data_bits = bits[pos:]
-                
-            try:
-                data_bytes = BitArray(data_bits).tobytes()
-            except:
-                data_bytes = b''
-                
-            # Append and Finalize
-            self.fragment_buffer.extend(data_bytes)
-            
-            # Restore metadata
-            if self.fragment_metadata:
-                encrypted = self.fragment_metadata.get('encrypted', False)
-                address = self.fragment_metadata.get('address')
+            data_bits = bits[2:]
+            data_bytes = _bits_to_bytes(data_bits)
+            length = len(data_bytes)
 
         if encrypted:
             self.stats['encrypted_frames'] += 1
         else:
             self.stats['clear_mode_frames'] += 1
-        
-        # Create PDU
+
         pdu = MacPDU(
             pdu_type=pdu_type,
             encrypted=encrypted,
             address=address,
             length=length,
             data=data_bytes,
-            fill_bits=fill_bit_ind,
-            encryption_mode=encryption_mode_val
+            data_bits=data_bits,
+            tm_sdu_bits=tm_sdu_bits,
+            crc_ok=crc_ok,
+            extra=extra or None,
         )
-        
-        # Attach reassembled data if this is the end
-        # Logic:
-        # 1. MAC-RESOURCE with full length (no fragmentation) -> Single packet
-        # 2. MAC-END -> End of fragmentation chain
-        
-        # Check if MAC-RESOURCE is self-contained (not fragmented)
-        # Usually indicated by a flag or context, but here we assume if it's MAC-RESOURCE
-        # and we don't see a "More Bit" (which we haven't parsed yet), it might be single.
-        # BUT, standard says MAC-RESOURCE starts a transaction.
-        # If we treat every MAC-RESOURCE as start of buffer, and MAC-END as end.
-        
-        if pdu_type == PDUType.MAC_END:
-             if self.fragment_buffer:
-                pdu.reassembled_data = bytes(self.fragment_buffer)
-                if self.fragment_metadata:
-                    if not pdu.address: pdu.address = self.fragment_metadata.get('address')
-                    # Inherit encryption from start of chain
-                    pdu.encrypted = self.fragment_metadata.get('encrypted', False)
-                
-                # Clear buffer
-                self.fragment_buffer = bytearray()
-                self.fragment_metadata = {}
-        
-        elif pdu_type == PDUType.MAC_RESOURCE:
-            # If this is a single-slot message (no fragmentation), we should treat it as such.
-            # However, without parsing the "More Bit" (TM-SDU header), we can't be sure.
-            # Heuristic: If length is small enough to fit in slot and we don't see MAC-FRAG next...
-            # Better: Always expose current data, but also expose reassembled if MAC-END.
-            # For MAC-RESOURCE, we just started the buffer. If it's a short message, 
-            # it might be the whole message.
-            # Let's tentatively set reassembled_data to current data for MAC-RESOURCE
-            # so single-frame messages work.
-            pdu.reassembled_data = bytes(data_bytes)
-            
+
+        pdu.reassembled_data = bytes(data_bytes) if data_bytes else None
         return pdu
+
+    @staticmethod
+    def _is_valid_ssi(value: Optional[int]) -> bool:
+        """Validate a 24-bit SSI/GSSI value."""
+        if value is None:
+            return False
+        return 0 < value < 0xFFFFFF and value != 0xFFFFFF
+
+    def _resource_talkgroup(self, resource: dict) -> Optional[int]:
+        """Extract SSI/GSSI from resource address if applicable."""
+        if not resource:
+            return None
+        addr_type = resource.get("addr_type")
+        if addr_type in (0, 2):
+            return None
+        talkgroup = resource.get("ssi") or resource.get("address")
+        if not self._is_valid_ssi(talkgroup):
+            return None
+        return talkgroup
+
+    @staticmethod
+    def _bits_to_uint(bit_arr: np.ndarray, start: int, length: int, *, lsb: bool = False) -> int:
+        """Convert a slice of bits into an integer (MSB-first by default)."""
+        val = 0
+        end = min(start + length, len(bit_arr))
+        if lsb:
+            shift = 0
+            for bit in bit_arr[start:end]:
+                val |= (int(bit) & 1) << shift
+                shift += 1
+        else:
+            for bit in bit_arr[start:end]:
+                val = (val << 1) | (int(bit) & 1)
+        return val
+
+    def _llc_defrag_add(self, ns: int, ss: int, payload: np.ndarray, final_ss: Optional[int]) -> Optional[np.ndarray]:
+        entry = self._llc_defrag.get(ns)
+        if entry is None:
+            entry = {"segments": {}, "final": None}
+            self._llc_defrag[ns] = entry
+        segments: Dict[int, np.ndarray] = entry["segments"]  # type: ignore[assignment]
+        segments[ss] = np.array(payload, copy=True)
+        if final_ss is not None:
+            entry["final"] = final_ss
+
+        final = entry["final"]
+        if final is None:
+            return None
+        if not all(idx in segments for idx in range(final + 1)):
+            return None
+        assembled = np.concatenate([segments[idx] for idx in range(final + 1)])
+        del self._llc_defrag[ns]
+        return assembled
+
+    def _parse_llc_pdu(self, bits: np.ndarray) -> Optional[np.ndarray]:
+        """Parse LLC PDU and return TL-SDU bits if available."""
+        if bits is None or len(bits) < 4:
+            return None
+        if np.any((bits != 0) & (bits != 1)):
+            bits = (bits < 0).astype(np.uint8)
+        else:
+            bits = bits.astype(np.uint8, copy=False)
+
+        def bits_to_uint(start: int, length: int) -> int:
+            val = 0
+            end = min(start + length, len(bits))
+            for bit in bits[start:end]:
+                val = (val << 1) | (int(bit) & 1)
+            return val
+
+        pdu_type = bits_to_uint(0, 4)
+        cur = 4
+        tl_sdu_bits = None
+        ss = 0
+        ns = 0
+        final_ss = None
+
+        if pdu_type in (0, 4):  # BL-ADATA / BL-ADATA-FCS
+            if cur + 2 > len(bits):
+                return None
+            cur += 2  # NR + NS
+            tl_sdu_bits = bits[cur:]
+            if pdu_type == 4 and len(tl_sdu_bits) >= 32:
+                tl_sdu_bits = tl_sdu_bits[:-32]
+        elif pdu_type in (1, 5):  # BL-DATA / BL-DATA-FCS
+            if cur + 1 > len(bits):
+                return None
+            cur += 1  # NS
+            tl_sdu_bits = bits[cur:]
+            if pdu_type == 5 and len(tl_sdu_bits) >= 32:
+                tl_sdu_bits = tl_sdu_bits[:-32]
+        elif pdu_type in (2, 6):  # BL-UDATA / BL-UDATA-FCS
+            tl_sdu_bits = bits[cur:]
+            if pdu_type == 6 and len(tl_sdu_bits) >= 32:
+                tl_sdu_bits = tl_sdu_bits[:-32]
+        elif pdu_type in (3, 7):  # BL-ACK / BL-ACK-FCS
+            if cur + 1 > len(bits):
+                return None
+            cur += 1  # NR
+            tl_sdu_bits = bits[cur:]
+            if pdu_type == 7 and len(tl_sdu_bits) >= 32:
+                tl_sdu_bits = tl_sdu_bits[:-32]
+        elif pdu_type == 9:  # AL-DATA/FINAL
+            if cur + 1 > len(bits):
+                return None
+            final = bits[cur]
+            cur += 1
+            if final:
+                if cur + 1 + 3 + 8 > len(bits):
+                    return None
+                cur += 1  # AL_FINAL_AR
+                ns = bits_to_uint(cur, 3); cur += 3
+                ss = bits_to_uint(cur, 8); cur += 8
+                final_ss = ss
+                tl_sdu_bits = bits[cur:]
+            else:
+                if cur + 3 + 8 > len(bits):
+                    return None
+                ns = bits_to_uint(cur, 3); cur += 3
+                ss = bits_to_uint(cur, 8); cur += 8
+                tl_sdu_bits = bits[cur:]
+        elif pdu_type == 10:  # AL-UDATA/UFINAL
+            if cur + 1 > len(bits):
+                return None
+            final = bits[cur]
+            cur += 1
+            if cur + 8 + 8 > len(bits):
+                return None
+            ns = bits_to_uint(cur, 8); cur += 8
+            ss = bits_to_uint(cur, 8); cur += 8
+            tl_sdu_bits = bits[cur:]
+            if final:
+                final_ss = ss
+        else:
+            return None
+
+        if tl_sdu_bits is None or len(tl_sdu_bits) == 0:
+            return None
+        if pdu_type in (9, 10):
+            assembled = self._llc_defrag_add(ns, ss, tl_sdu_bits, final_ss)
+            return assembled
+        if ss != 0:
+            return None
+        return tl_sdu_bits
+
+    def _parse_cmce_metadata(self, mac_pdu: MacPDU) -> Optional[CallMetadata]:
+        """Parse CMCE call metadata from TM-SDU bits."""
+        tm_sdu_bits = mac_pdu.tm_sdu_bits
+        if tm_sdu_bits is None or mac_pdu.extra is None:
+            return None
+        tl_sdu_bits = self._parse_llc_pdu(tm_sdu_bits)
+        if tl_sdu_bits is None or len(tl_sdu_bits) < 8:
+            return None
+        mle_pdisc = self._bits_to_uint(tl_sdu_bits, 0, 3)
+        use_lsb = False
+        if mle_pdisc != 2:  # TMLE_PDISC_CMCE
+            mle_pdisc_lsb = self._bits_to_uint(tl_sdu_bits, 0, 3, lsb=True)
+            if mle_pdisc_lsb != 2:
+                return None
+            use_lsb = True
+
+        cmce_type = self._bits_to_uint(tl_sdu_bits, 3, 5, lsb=use_lsb)
+        cmce_type_alt = self._bits_to_uint(tl_sdu_bits, 3, 5, lsb=not use_lsb)
+        known_types = set(range(0x00, 0x11))
+        if cmce_type not in known_types and cmce_type_alt in known_types:
+            cmce_type = cmce_type_alt
+            use_lsb = not use_lsb
+
+        cmce_bits = tl_sdu_bits[3:]
+
+        def score_meta(meta: Optional[CallMetadata]) -> int:
+            if meta is None:
+                return -1
+            score = 0
+            if meta.source_ssi:
+                score += 2
+            if meta.dest_ssi:
+                score += 2
+            if meta.call_identifier is not None:
+                score += 1
+            if meta.talkgroup_id:
+                score += 1
+            return score
+
+        def pick_meta(primary: Optional[CallMetadata], alt: Optional[CallMetadata]) -> Optional[CallMetadata]:
+            if primary is None:
+                return alt
+            if alt is None:
+                return primary
+            return alt if score_meta(alt) > score_meta(primary) else primary
+
+        alt_lsb = not use_lsb
+
+        if cmce_type == 0x07:
+            return pick_meta(
+                self._parse_cmce_d_setup(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_setup(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x0B:
+            return pick_meta(
+                self._parse_cmce_d_tx_granted(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_tx_granted(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x09:
+            return pick_meta(
+                self._parse_cmce_d_tx_ceased(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_tx_ceased(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x08:
+            return pick_meta(
+                self._parse_cmce_d_status(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_status(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x06:
+            return pick_meta(
+                self._parse_cmce_d_release(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_release(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x02:
+            return pick_meta(
+                self._parse_cmce_d_connect(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_connect(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x0F:
+            return pick_meta(
+                self._parse_cmce_d_sds(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_sds(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        if cmce_type == 0x05:
+            return pick_meta(
+                self._parse_cmce_d_info(cmce_bits, mac_pdu.extra, lsb=use_lsb),
+                self._parse_cmce_d_info(cmce_bits, mac_pdu.extra, lsb=alt_lsb),
+            )
+        return None
+
+    def _parse_cmce_d_setup(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-SETUP message for call metadata."""
+        if bits is None or len(bits) < 30:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        call_ident = bits_to_uint(n, 14); n += 14
+        _ = bits_to_uint(n, 4); n += 4  # call timeout
+        _ = bits_to_uint(n, 1); n += 1  # hook method
+        _ = bits_to_uint(n, 1); n += 1  # duplex
+        _ = bits_to_uint(n, 8); n += 8  # basic info
+        _ = bits_to_uint(n, 2); n += 2  # tx grant
+        _ = bits_to_uint(n, 1); n += 1  # tx perm
+        _ = bits_to_uint(n, 4); n += 4  # call prio
+        if n >= len(bits):
+            return None
+        o_bit = bits_to_uint(n, 1); n += 1
+
+        calling_ssi = None
+        if o_bit:
+            if n < len(bits):
+                pbit_notif = bits_to_uint(n, 1); n += 1
+                if pbit_notif:
+                    n += 6
+            if n < len(bits):
+                pbit_temp = bits_to_uint(n, 1); n += 1
+                if pbit_temp:
+                    n += 24
+            if n < len(bits):
+                pbit_cpti = bits_to_uint(n, 1); n += 1
+                if pbit_cpti and n + 2 <= len(bits):
+                    cpti = bits_to_uint(n, 2); n += 2
+                    if cpti == 0 and n + 8 <= len(bits):
+                        n += 8
+                    elif cpti == 1 and n + 24 <= len(bits):
+                        calling_ssi = bits_to_uint(n, 24); n += 24
+                    elif cpti == 2 and n + 48 <= len(bits):
+                        calling_ssi = bits_to_uint(n, 24); n += 24
+                        n += 24  # extension
+
+        talkgroup = self._resource_talkgroup(resource)
+        if not self._is_valid_ssi(calling_ssi):
+            calling_ssi = None
+
+        return CallMetadata(
+            call_type="Group" if talkgroup is not None else "Individual",
+            talkgroup_id=talkgroup,
+            source_ssi=calling_ssi,
+            dest_ssi=None,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=call_ident,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_tx_granted(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-TX-GRANTED for caller SSI."""
+        if bits is None or len(bits) < 24:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        call_ident = bits_to_uint(n, 14); n += 14
+        _ = bits_to_uint(n, 2); n += 2  # tx grant
+        _ = bits_to_uint(n, 1); n += 1  # tx perm
+        _ = bits_to_uint(n, 1); n += 1  # enc control
+        _ = bits_to_uint(n, 1); n += 1  # reserved
+        if n >= len(bits):
+            return None
+        o_bit = bits_to_uint(n, 1); n += 1
+
+        tx_ssi = None
+        if o_bit:
+            if n < len(bits):
+                pbit_nid = bits_to_uint(n, 1); n += 1
+                if pbit_nid:
+                    n += 6
+            if n < len(bits):
+                pbit_tpti = bits_to_uint(n, 1); n += 1
+                if pbit_tpti and n + 2 <= len(bits):
+                    tpti = bits_to_uint(n, 2); n += 2
+                    if tpti == 0 and n + 8 <= len(bits):
+                        n += 8
+                    elif tpti == 1 and n + 24 <= len(bits):
+                        tx_ssi = bits_to_uint(n, 24); n += 24
+                    elif tpti == 2 and n + 48 <= len(bits):
+                        tx_ssi = bits_to_uint(n, 24); n += 24
+                        n += 24
+
+        if not self._is_valid_ssi(tx_ssi):
+            tx_ssi = None
+        talkgroup = self._resource_talkgroup(resource)
+
+        return CallMetadata(
+            call_type="Group" if talkgroup is not None else "Individual",
+            talkgroup_id=talkgroup,
+            source_ssi=tx_ssi,
+            dest_ssi=None,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=call_ident,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_sds(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-SDS DATA for source/destination SSI."""
+        if bits is None or len(bits) < 7:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        cpti = bits_to_uint(n, 2); n += 2
+        calling_ssi = None
+        if cpti == 0 and n + 8 <= len(bits):
+            n += 8
+        elif cpti == 1 and n + 24 <= len(bits):
+            calling_ssi = bits_to_uint(n, 24)
+            n += 24
+        elif cpti == 2 and n + 48 <= len(bits):
+            calling_ssi = bits_to_uint(n, 24)
+            n += 48
+
+        dest_ssi = self._resource_talkgroup(resource)
+        if not self._is_valid_ssi(calling_ssi):
+            calling_ssi = None
+        if not self._is_valid_ssi(dest_ssi):
+            dest_ssi = None
+
+        return CallMetadata(
+            call_type="SDS",
+            talkgroup_id=None,
+            source_ssi=calling_ssi,
+            dest_ssi=dest_ssi,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=None,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_info(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-INFO (best-effort for call identifier)."""
+        if bits is None or len(bits) < 19:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        call_ident = bits_to_uint(n, 14)
+
+        talkgroup = self._resource_talkgroup(resource)
+
+        return CallMetadata(
+            call_type="Info",
+            talkgroup_id=talkgroup,
+            source_ssi=None,
+            dest_ssi=None,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=call_ident,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_status(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-STATUS for calling SSI."""
+        if bits is None or len(bits) < 24:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        cpti = bits_to_uint(n, 2); n += 2
+        calling_ssi = None
+        if cpti == 0 and n + 8 <= len(bits):
+            n += 8
+        elif cpti == 1 and n + 24 <= len(bits):
+            calling_ssi = bits_to_uint(n, 24); n += 24
+        elif cpti == 2 and n + 48 <= len(bits):
+            calling_ssi = bits_to_uint(n, 24); n += 24
+            n += 24
+
+        talkgroup = self._resource_talkgroup(resource)
+        if not self._is_valid_ssi(calling_ssi):
+            calling_ssi = None
+
+        return CallMetadata(
+            call_type="Status",
+            talkgroup_id=talkgroup,
+            source_ssi=calling_ssi,
+            dest_ssi=None,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=None,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_release(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-RELEASE for call identifier."""
+        if bits is None or len(bits) < 26:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        call_ident = bits_to_uint(n, 14); n += 14
+
+        talkgroup = self._resource_talkgroup(resource)
+
+        return CallMetadata(
+            call_type="Release",
+            talkgroup_id=talkgroup,
+            source_ssi=None,
+            dest_ssi=None,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=call_ident,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_connect(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-CONNECT for call identifier."""
+        if bits is None or len(bits) < 24:
+            return None
+        bits_to_uint = lambda start, length: self._bits_to_uint(bits, start, length, lsb=lsb)
+
+        n = 0
+        _ = bits_to_uint(n, 5); n += 5  # pdu_type
+        call_ident = bits_to_uint(n, 14); n += 14
+
+        talkgroup = self._resource_talkgroup(resource)
+
+        return CallMetadata(
+            call_type="Connect",
+            talkgroup_id=talkgroup,
+            source_ssi=None,
+            dest_ssi=None,
+            channel_allocated=resource.get("carrier"),
+            call_identifier=call_ident,
+            call_priority=0,
+            mcc=self.mcc,
+            mnc=self.mnc,
+            encryption_enabled=resource.get("encryption_mode", 0) > 0,
+            encryption_algorithm="TEA1" if resource.get("encryption_mode", 0) > 0 else None,
+        )
+
+    def _parse_cmce_d_tx_ceased(self, bits: np.ndarray, resource: dict, *, lsb: bool = False) -> Optional[CallMetadata]:
+        """Parse CMCE D-TX-CEASED (best-effort, similar to D-TX-GRANTED)."""
+        return self._parse_cmce_d_tx_granted(bits, resource, lsb=lsb)
+
     def parse_call_metadata(self, mac_pdu: MacPDU) -> Optional[CallMetadata]:
         """
         Extract call metadata from MAC PDU (talkgroup, SSI, etc.).
@@ -604,20 +1263,38 @@ class TetraProtocolParser:
         Returns:
             CallMetadata or None
         """
-        if not mac_pdu or len(mac_pdu.data) < 4:
+        if not mac_pdu:
             return None
-        
-        # Parse based on PDU type
+
+        if mac_pdu.tm_sdu_bits is not None and mac_pdu.extra:
+            cmce_meta = self._parse_cmce_metadata(mac_pdu)
+            if cmce_meta:
+                if cmce_meta.source_ssi:
+                    self._ssi_votes[cmce_meta.source_ssi] += 1
+                if cmce_meta.dest_ssi:
+                    self._ssi_votes[cmce_meta.dest_ssi] += 1
+                if mac_pdu.crc_ok is False:
+                    ssi_values = [v for v in (cmce_meta.source_ssi, cmce_meta.dest_ssi) if v]
+                    if not ssi_values:
+                        return None
+                    if not any(self._ssi_votes[v] >= 2 for v in ssi_values):
+                        return None
+                return cmce_meta
+
+        if mac_pdu.crc_ok is False:
+            return None
+
+        if mac_pdu.encrypted:
+            return None
+
+        # Parse based on PDU type (fallback)
         if mac_pdu.pdu_type == PDUType.MAC_RESOURCE:
-            # Resource assignment - contains channel allocation
             return self._parse_resource_assignment(mac_pdu)
-        elif mac_pdu.pdu_type == PDUType.MAC_U_SIGNAL:
-            # Signaling - contains call setup
+        if mac_pdu.pdu_type == PDUType.MAC_U_SIGNAL:
             return self._parse_call_setup(mac_pdu)
-        elif mac_pdu.pdu_type == PDUType.MAC_BROADCAST:
-            # Broadcast - contains network info
+        if mac_pdu.pdu_type == PDUType.MAC_BROADCAST:
             return self._parse_broadcast(mac_pdu)
-        
+
         return None
     
     def _parse_resource_assignment(self, mac_pdu: MacPDU) -> Optional[CallMetadata]:
@@ -625,41 +1302,28 @@ class TetraProtocolParser:
         data = mac_pdu.data
         if len(data) < 8:
             return None
-        
-        # Extract fields (Heuristic mapping)
-        # Byte 0: [CallType(1) | ... ]
+
         call_type = "Group" if data[0] & 0x80 else "Individual"
-        
-        # Bytes 1-3: Talkgroup/SSI (24 bits)
-        talkgroup_id = int.from_bytes(data[1:4], 'big') & 0xFFFFFF
-        
-        # Byte 4: Channel Allocation
-        channel_allocated = data[4] & 0x3F
-        
-        # Byte 5: Encryption & Priority
-        encryption_enabled = bool(data[5] & 0x80)
-        call_priority = (data[5] >> 2) & 0x0F  # Guessing priority location (4 bits)
-        
-        # Bytes 6-7: Call Identifier (14 bits)
-        # Usually in the lower bits of byte 6 and upper of byte 7
-        call_identifier = ((data[6] & 0x0F) << 10) | (data[7] << 2) # Rough guess
-        
-        # Try to find Source SSI (Calling Party) in the payload (TM-SDU)
-        # This is a heuristic search for a 24-bit SSI that is NOT the talkgroup
+
+        talkgroup_id = None
         source_ssi = None
-        if len(data) > 10:
-            # Scan for potential SSIs (3 bytes)
-            # Valid SSI range: 1 - 16777215 (0 is reserved, >16M is reserved/short)
-            # We skip the first few bytes which are MAC header
-            for i in range(8, len(data) - 3):
-                val = int.from_bytes(data[i:i+3], 'big') & 0xFFFFFF
-                # Heuristic: SSI should be different from TG, and look "reasonable"
-                # Most user SSIs are > 1000 and < 16000000
-                if val != talkgroup_id and 1000 < val < 16000000:
-                    # Check if it looks like a valid SSI (not all FFs or 00s)
-                    if val != 0xFFFFFF and val != 0:
-                        source_ssi = val
-                        break
+        if mac_pdu.extra:
+            talkgroup_id = self._resource_talkgroup(mac_pdu.extra)
+        if talkgroup_id is None and self._is_valid_ssi(mac_pdu.address):
+            talkgroup_id = mac_pdu.address
+
+        channel_allocated = None
+        if mac_pdu.extra:
+            channel_allocated = mac_pdu.extra.get("carrier")
+
+        encryption_enabled = False
+        if mac_pdu.extra and mac_pdu.extra.get("encryption_mode"):
+            encryption_enabled = mac_pdu.extra.get("encryption_mode", 0) > 0
+        call_priority = (data[5] >> 2) & 0x0F if len(data) > 5 else 0
+
+        call_identifier = None
+        if len(data) > 7:
+            call_identifier = ((data[6] & 0x0F) << 10) | (data[7] << 2)
         
         self.stats['control_messages'] += 1
         
@@ -686,6 +1350,10 @@ class TetraProtocolParser:
         # Extract SSIs
         source_ssi = int.from_bytes(data[0:3], 'big') & 0xFFFFFF
         dest_ssi = int.from_bytes(data[3:6], 'big') & 0xFFFFFF
+        if not self._is_valid_ssi(source_ssi):
+            source_ssi = None
+        if not self._is_valid_ssi(dest_ssi):
+            dest_ssi = None
         
         # Call type
         call_type_byte = data[6]
@@ -712,7 +1380,7 @@ class TetraProtocolParser:
         
         return CallMetadata(
             call_type=call_type,
-            talkgroup_id=dest_ssi if call_type == "Voice" else None,
+            talkgroup_id=dest_ssi if call_type == "Voice" and dest_ssi is not None else None,
             source_ssi=source_ssi,
             dest_ssi=dest_ssi,
             channel_allocated=None,
@@ -762,11 +1430,8 @@ class TetraProtocolParser:
                 logger.debug(f"Invalid MNC {mnc} - likely noise, not real TETRA")
                 return None
             
-            # Update parser state
-            self.mcc = mcc
-            self.mnc = mnc
-            self.colour_code = colour_code
-            
+            self._record_network_candidate(mcc, mnc, colour_code, strong=mac_pdu.crc_ok is True)
+
             logger.info(f"Decoded TETRA network: MCC={mcc} MNC={mnc} CC={colour_code}")
             
             # Return metadata with just network info

--- a/tetraear/signal/processor.py
+++ b/tetraear/signal/processor.py
@@ -9,8 +9,12 @@ Implements π/4-DQPSK demodulation according to TETRA specifications:
 """
 
 import numpy as np
-from scipy import signal
 import logging
+
+try:
+    from scipy import signal as scipy_signal
+except Exception:  # pragma: no cover - optional dependency
+    scipy_signal = None
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +35,7 @@ class SignalProcessor:
         self.samples_per_symbol = int(sample_rate / self.symbol_rate)
         # Store symbols for voice extraction
         self.symbols = None
+        self.symbol_confidence = None
         
     def resample(self, samples, target_rate):
         """
@@ -45,7 +50,13 @@ class SignalProcessor:
         """
         num_samples = len(samples)
         new_num_samples = int(num_samples * target_rate / self.sample_rate)
-        resampled = signal.resample(samples, new_num_samples)
+        if scipy_signal is not None:
+            resampled = scipy_signal.resample(samples, new_num_samples)
+        else:
+            # Fallback: linear interpolation resample
+            x_old = np.linspace(0, 1, num_samples, endpoint=False)
+            x_new = np.linspace(0, 1, new_num_samples, endpoint=False)
+            resampled = np.interp(x_new, x_old, samples).astype(samples.dtype)
         return resampled
     
     def filter_signal(self, samples, bandwidth=25000, sample_rate=None):
@@ -75,8 +86,10 @@ class SignalProcessor:
         cutoff = min(0.99, max(0.01, cutoff))  # Ensure valid range
         
         try:
-            b, a = signal.butter(4, cutoff, btype='low')
-            filtered = signal.filtfilt(b, a, samples)
+            if scipy_signal is None:
+                return self._fir_filter(samples, bandwidth / 2, fs)
+            b, a = scipy_signal.butter(4, cutoff, btype='low')
+            filtered = scipy_signal.filtfilt(b, a, samples)
             return filtered
         except Exception as e:
             logger.warning(f"Filter design failed, using unfiltered samples: {e}")
@@ -128,6 +141,7 @@ class SignalProcessor:
         
         # Differential detection: phase difference between consecutive symbols
         symbols = []
+        confidences = []
         prev_sample = samples[0]
         
         # TETRA π/4-DQPSK uses 8 constellation points at multiples of π/4
@@ -149,20 +163,22 @@ class SignalProcessor:
             # -π/4  -> Bits (1,0) -> Symbol 2
             # -3π/4 -> Bits (1,1) -> Symbol 3
             
-            if phase_diff < -5*np.pi/8:
-                symbol = 3  # Closest to -3π/4 (bits: 1,1)
-            elif phase_diff < -3*np.pi/8:
-                symbol = 2  # Closest to -π/4 (bits: 1,0)
-            elif phase_diff < 3*np.pi/8:
-                symbol = 0  # Closest to +π/4 (bits: 0,0)
-            elif phase_diff < 5*np.pi/8:
-                symbol = 1  # Closest to +3π/4 (bits: 0,1)
-            else:
-                symbol = 3  # Wrap around to -3π/4
+            # Ideal phase transitions (π/4-DQPSK)
+            ideal_angles = np.array([np.pi/4, 3*np.pi/4, -np.pi/4, -3*np.pi/4])
+            # Normalize diff to [-pi, pi]
+            diffs = np.abs(np.angle(np.exp(1j * (phase_diff - ideal_angles))))
+            closest_idx = int(np.argmin(diffs))
+            symbol = [0, 1, 2, 3][closest_idx]
+
+            # Confidence: 1.0 when exactly on symbol, 0 at decision boundary
+            conf = 1.0 - (diffs[closest_idx] / (np.pi / 4))
+            conf = float(np.clip(conf, 0.0, 1.0))
             
             symbols.append(symbol)
+            confidences.append(conf)
             prev_sample = sample
         
+        self.symbol_confidence = np.array(confidences, dtype=np.float32)
         return np.array(symbols, dtype=np.uint8)
     
     def extract_symbols(self, samples, sample_rate=None):
@@ -240,21 +256,32 @@ class SignalProcessor:
             self.symbols = np.array([], dtype=complex)
             return np.array([], dtype=np.uint8)
             
-        # Handle high sample rates by decimating first
-        # Target ~240 kHz which is sufficient for TETRA (25kHz BW) and allows for some frequency offset
-        target_rate = 240000
+        # Handle high sample rates by resampling/decimating first
+        # Target a multiple of the symbol rate for cleaner timing recovery.
+        target_rate = 288000  # 16 * 18 kHz
         current_rate = self.sample_rate
-        
-        if current_rate > target_rate * 2:
-            decimation_factor = int(current_rate / target_rate)
-            if decimation_factor > 1:
-                # Use scipy.signal.decimate which includes a low-pass filter to prevent aliasing
-                # This is much more efficient than processing at full rate
+
+        if current_rate > target_rate * 1.5:
+            ratio = current_rate / target_rate
+            if abs(ratio - round(ratio)) < 1e-3:
+                decimation_factor = int(round(ratio))
+                if decimation_factor > 1:
+                    try:
+                        if scipy_signal is not None:
+                            samples = scipy_signal.decimate(samples, decimation_factor)
+                        else:
+                            cutoff = 0.45 * target_rate
+                            samples = self._fir_filter(samples, cutoff, current_rate)
+                            samples = samples[::decimation_factor]
+                        current_rate = current_rate / decimation_factor
+                    except Exception as e:
+                        logger.warning(f"Decimation failed: {e}")
+            else:
                 try:
-                    samples = signal.decimate(samples, decimation_factor)
-                    current_rate = current_rate / decimation_factor
+                    samples = self.resample(samples, target_rate)
+                    current_rate = target_rate
                 except Exception as e:
-                    logger.warning(f"Decimation failed: {e}")
+                    logger.warning(f"Resample failed: {e}")
         
         # Apply frequency correction if needed
         if freq_offset != 0:
@@ -271,3 +298,18 @@ class SignalProcessor:
         demodulated = self.demodulate_dqpsk(symbols)
         
         return demodulated
+
+    def _fir_filter(self, samples, cutoff_hz, sample_rate):
+        """Simple FIR low-pass filter fallback when SciPy is unavailable."""
+        if len(samples) == 0:
+            return samples
+        nyquist = sample_rate / 2
+        cutoff = min(0.99 * nyquist, max(1.0, cutoff_hz))
+        norm = cutoff / nyquist
+        numtaps = 101
+        n = np.arange(numtaps) - (numtaps - 1) / 2
+        h = 2 * norm * np.sinc(2 * norm * n)
+        window = np.hamming(numtaps)
+        h *= window
+        h /= np.sum(h)
+        return np.convolve(samples, h, mode="same")

--- a/tetraear/signal/scanner.py
+++ b/tetraear/signal/scanner.py
@@ -169,7 +169,7 @@ class TetraSignalDetector:
             
             # Try to decode frames
             decoder = TetraDecoder(auto_decrypt=False)  # Don't try decryption for validation
-            frames = decoder.decode(demodulated)
+            frames = decoder.decode(demodulated, confidences=processor.symbol_confidence)
             
             if len(frames) == 0:
                 return False, 0.0

--- a/tetraear/tools/rtl_auto_capture.py
+++ b/tetraear/tools/rtl_auto_capture.py
@@ -184,7 +184,7 @@ def main() -> int:
                 if demodulated is None or len(demodulated) < 255:
                     continue
 
-                frames = decoder.decode(demodulated)
+                frames = decoder.decode(demodulated, confidences=processor.symbol_confidence)
                 if not frames:
                     continue
 

--- a/tetraear/ui/modern.py
+++ b/tetraear/ui/modern.py
@@ -338,7 +338,8 @@ class SettingsManager:
         "bandwidth": 25000,
         "zoom_level": 1.0,
         "noise_floor": -85,
-        "theme": "dark"
+        "theme": "dark",
+        "expected_mcc": None
     }
     
     def __init__(self, filename="settings.json"):
@@ -597,7 +598,7 @@ class AboutDialog(QDialog):
         
         # Version and info
         info_label = QLabel("""
-        <h2 style="color: #3b82f6;">TETRA Decoder Pro v2.0</h2>
+        <h2 style="color: #3b82f6;">TETRA Decoder Pro v2.3</h2>
         <p style="color: #a1a1aa;">Professional TETRA signal decoder with real-time spectrum analysis</p>
         <p style="color: #888888;">Features:</p>
         <ul style="color: #a1a1aa;">
@@ -2022,15 +2023,13 @@ class CaptureThread(QThread):
                             demodulated = self.processor.process(samples, freq_offset=afc_offset)
                             
                             # Store demodulated symbols for voice extraction
-                            # Get symbols from processor if available
+                            # Use the hard-decision symbol stream (0-3) for codec input.
+                            self.demodulated_symbols = demodulated if isinstance(demodulated, np.ndarray) else None
+                            # Keep complex symbols separately if needed for future diagnostics.
                             if hasattr(self.processor, 'symbols'):
-                                self.demodulated_symbols = self.processor.symbols
+                                self.demodulated_complex = self.processor.symbols
                             elif hasattr(self.processor, 'get_symbols'):
-                                self.demodulated_symbols = self.processor.get_symbols()
-                            else:
-                                # Extract symbols from demodulated (if it's symbol stream)
-                                # For now, store demodulated as symbols (may need adjustment)
-                                self.demodulated_symbols = demodulated if isinstance(demodulated, np.ndarray) else None
+                                self.demodulated_complex = self.processor.get_symbols()
                             
                             # Calculate samples per symbol (typically 4 for π/4-DQPSK at 18k samples/sec)
                             # TETRA symbol rate is 18k symbols/sec, so at 180k samples/sec: 10 samples/symbol
@@ -2067,7 +2066,10 @@ class CaptureThread(QThread):
                                 if demodulated is None or len(demodulated) < 255:
                                     frames = []
                                 else:
-                                    frames = self.decoder.decode(demodulated)
+                                    frames = self.decoder.decode(
+                                        demodulated,
+                                        confidences=getattr(self.signal_processor, "symbol_confidence", None),
+                                    )
                                     # Log when frames are found (but limit logging frequency)
                                     if len(frames) > 0:
                                         import time
@@ -2092,12 +2094,9 @@ class CaptureThread(QThread):
                                             pdu_type = str(mac_pdu.get('type', ''))
                                             is_encrypted = frame.get('encrypted', False)
                                             
-                                            # Voice candidates: MAC-FRAG/traffic. Allow encrypted frames only if
-                                            # they were successfully decrypted (so we can feed clear bits to the codec).
-                                            is_voice_candidate = (
-                                                ('FRAG' in pdu_type or frame.get('type') == 1)
-                                                and (not is_encrypted or frame.get('decrypted'))
-                                            )
+                                            # Voice candidates: attempt on any non-broadcast burst.
+                                            # Some traffic bursts are misclassified without full FEC decode.
+                                            is_voice_candidate = frame.get('type_name') != 'MAC-BROADCAST'
                                             
                                             if is_voice_candidate:
                                                 # Extract raw bits from the frame
@@ -2127,11 +2126,15 @@ class CaptureThread(QThread):
                                                     except Exception as e:
                                                         logger.debug(f"Error using decrypted payload: {e}")
 
-                                                # Try to extract voice slot from symbol stream (preferred method)
-                                                codec_input = None
-                                                # Only use symbols if NOT encrypted (symbols are raw/encrypted)
-                                                if not frame.get('encrypted') and hasattr(self, 'demodulated_symbols') and self.demodulated_symbols is not None:
-                                                    codec_input = self._extract_voice_slot_from_symbols(frame, self.demodulated_symbols, self.samples_per_symbol)
+                                                # Prefer decoded codec input from the lower-MAC pipeline.
+                                                codec_input = frame.get("codec_input")
+
+                                                # Fallback to symbol-based extraction for legacy paths.
+                                                if codec_input is None and hasattr(self, 'demodulated_symbols') and self.demodulated_symbols is not None:
+                                                    if self.tch_assembler:
+                                                        codec_input = self.tch_assembler.add_burst(self.demodulated_symbols, frame.get('position'))
+                                                    else:
+                                                        codec_input = self._extract_voice_slot_from_symbols(frame, self.demodulated_symbols, self.samples_per_symbol)
                                                 
                                                 # If extraction from symbols failed, try alternative method
                                                 if codec_input is None and voice_bits is not None and len(voice_bits) >= 432:
@@ -2305,109 +2308,10 @@ class CaptureThread(QThread):
         Returns soft bits (16-bit integers) in TETRA format (690 shorts = 1380 bytes).
         """
         try:
-            import struct
-            
-            # Get frame position in symbol stream (in bits, not symbols)
+            from tetraear.audio.tch import extract_tch_codec_input
+
             pos = frame.get('position')
-            if pos is None:
-                return None
-            
-            # Convert bit position to symbol position (3 bits per symbol for π/4-DQPSK)
-            symbol_pos = pos // 3
-                
-            # TETRA slot is 255 symbols (510 bits)
-            if symbol_pos + 255 > len(demodulated_symbols):
-                return None
-                
-            slot_symbols = demodulated_symbols[symbol_pos:symbol_pos+255]
-            
-            # Convert symbols to soft bits for codec
-            # π/4-DQPSK has 2 bits per symbol (dibits)
-            soft_bits = []
-            
-            # Normal burst structure:
-            # First block: 108 symbols (216 bits)
-            # Training: 11 symbols (22 bits)
-            # Second block: 108 symbols (216 bits)
-            # Total: 227 symbols before tail
-            
-            # Extract first block (108 symbols = 216 bits)
-            for i in range(108):
-                if i >= len(slot_symbols):
-                    break
-                sym = int(slot_symbols[i])
-                # Extract 2 bits from symbol (MSB first)
-                bit1 = (sym >> 1) & 1
-                bit0 = sym & 1
-                # Convert to soft bits: 1 -> +16384, 0 -> -16384
-                soft_bits.append(16384 if bit1 else -16384)
-                soft_bits.append(16384 if bit0 else -16384)
-            
-            # Skip training sequence (11 symbols at position 108-118)
-            
-            # Extract second block (108 symbols = 216 bits)
-            for i in range(119, 227):
-                if i >= len(slot_symbols):
-                    break
-                sym = int(slot_symbols[i])
-                bit1 = (sym >> 1) & 1
-                bit0 = sym & 1
-                soft_bits.append(16384 if bit1 else -16384)
-                soft_bits.append(16384 if bit0 else -16384)
-            
-            # Now we have 432 soft bits (216 from each block)
-            # cdecoder expects 690 shorts with specific structure matching Write_Tetra_File format
-            # Soft bits must be in range -127 to +127 (masked with 0x00FF)
-            
-            # Create 690-short block structure
-            block = [0] * 690
-            
-            # Header: 0x6B21 for speech frame
-            block[0] = 0x6B21
-            
-            # Convert soft bits to proper range (-127 to +127)
-            # Current soft_bits are ±16384, need to scale to ±127
-            scaled_soft_bits = []
-            for sb in soft_bits:
-                # Scale from ±16384 to ±127 range
-                scaled = int((sb / 16384.0) * 127)
-                # Clamp to valid range
-                scaled = max(-127, min(127, scaled))
-                scaled_soft_bits.append(scaled)
-            
-            # Place 432 soft bits in correct positions according to Write_Tetra_File structure
-            # Block 1: positions 1-114 (114 bits)
-            # Block 2: positions 116-229 (114 bits) 
-            # Block 3: positions 231-344 (114 bits)
-            # Block 4: positions 346-435 (90 bits)
-            
-            idx = 0
-            # Block 1: positions 1-114
-            for i in range(1, 115):
-                if idx < len(scaled_soft_bits):
-                    block[i] = scaled_soft_bits[idx]  # No mask for signed short
-                    idx += 1
-            
-            # Block 2: positions 116-229 (161-45=116)
-            for i in range(116, 230):
-                if idx < len(scaled_soft_bits):
-                    block[i] = scaled_soft_bits[idx]
-                    idx += 1
-            
-            # Block 3: positions 231-344 (321-45-45=231)
-            for i in range(231, 345):
-                if idx < len(scaled_soft_bits):
-                    block[i] = scaled_soft_bits[idx]
-                    idx += 1
-            
-            # Block 4: positions 346-435 (481-45-45-45=346, 90 values)
-            for i in range(346, 436):
-                if idx < len(scaled_soft_bits):
-                    block[i] = scaled_soft_bits[idx]
-                    idx += 1
-            
-            # Pack as little-endian signed shorts
-            return struct.pack(f'<{len(block)}h', *block)
+            return extract_tch_codec_input(demodulated_symbols, pos)
             
         except Exception as e:
             logger.debug(f"Error extracting voice slot: {e}")
@@ -2513,7 +2417,7 @@ class ModernTetraGUI(QMainWindow):
     
     def __init__(self):
         super().__init__()
-        self.setWindowTitle("TetraEar - Professional TETRA Decoder v2.0")
+        self.setWindowTitle("TetraEar - Professional TETRA Decoder v2.3")
         self.setGeometry(100, 100, 1600, 1100)
         
         # Set application icon
@@ -2552,13 +2456,21 @@ class ModernTetraGUI(QMainWindow):
         self.recording_enabled = False  # Manual recording toggle
         self.recording_start_time = None
         self.recording_has_audio = False  # Track if valid audio was recorded
+        self.tch_assembler = None
         
         # Managers
         self.settings_manager = SettingsManager()
         self.freq_manager = FrequencyManager()
         
-        # TETRA signal validator (expect Poland MCC 260)
-        self.signal_validator = TetraSignalValidator(expected_country_mcc=260)
+        # TETRA signal validator (optionally constrain by expected MCC)
+        expected_mcc = self.settings_manager.get("expected_mcc", None)
+        self.signal_validator = TetraSignalValidator(expected_country_mcc=expected_mcc)
+
+        try:
+            from tetraear.audio.tch import TchFrameAssembler
+            self.tch_assembler = TchFrameAssembler()
+        except Exception:
+            self.tch_assembler = None
         
         self.init_ui()
         self.apply_modern_style()
@@ -4121,6 +4033,7 @@ class ModernTetraGUI(QMainWindow):
         
         # Play audio LIVE if monitoring enabled
         if self.hear_voice_cb.isChecked() and len(data) > 0:
+            play_data = np.clip(data.astype(np.float32), -1.0, 1.0)
             try:
                 # Ensure audio stream exists and is started
                 if not hasattr(self, 'audio_stream') or self.audio_stream is None:
@@ -4136,8 +4049,7 @@ class ModernTetraGUI(QMainWindow):
                         self.audio_stream.start()
                     
                     # Write audio data - YOU WILL HEAR THIS LIVE!
-                    # Normalize int16 to float32 range [-1.0, 1.0]
-                    self.audio_stream.write(data.astype(np.float32) / 32768.0)
+                    self.audio_stream.write(play_data)
             except Exception as e:
                 logger.debug(f"Audio playback error: {e}")
                 # Try to reinitialize audio stream
@@ -4149,7 +4061,7 @@ class ModernTetraGUI(QMainWindow):
                             pass
                     self.init_audio()
                     if hasattr(self, 'audio_stream') and self.audio_stream:
-                        self.audio_stream.write(data.astype(np.float32) / 32768.0)
+                        self.audio_stream.write(play_data)
                 except Exception as e2:
                     logger.debug(f"Audio reinit failed: {e2}")
 


### PR DESCRIPTION
Summary

Release v2.3 with restored TCH audio, improved call control parsing, and a new offline IQ analyzer.
Key Changes

Added pure‑Python lower‑MAC/FEC pipeline and TCH codec input assembly for reliable voice decode.

Fixed MAC‑FRAG/MAC‑END handling and improved CMCE parsing to reduce wrong MCC/MNC, GSSI, ISSI.

Decoder now accepts soft‑bit confidence for better FEC performance.

Added [analyze_iq.py](app://-/index.html#) for offline IQ analysis with multi‑carrier support and log comparison.

Added [install_tetra_codec.sh](app://-/index.html#) to download ETSI codec and build cdecoder/sdecoder.

Bumped version to 2.3 and updated changelog/release notes; refreshed About dialog version.

Updated .gitignore to ignore sample/ and built codec binaries.