### PR TITLE
Fix voice decoding: CaptureThread attributes, codec timeout, hidden c…

### DIFF
--- a/tetraear/audio/voice.py
+++ b/tetraear/audio/voice.py
@@ -20,6 +20,21 @@ import numpy as np
 logger = logging.getLogger(__name__)
 codec_logger = logging.getLogger("tetraear.codec")
 
+# Codec per-frame timeout. A too-aggressive timeout drops otherwise
+# decodable voice frames when the machine is slow or "cold" -- e.g. an
+# antivirus scanning the freshly built codec executables during the first
+# calls. Make it configurable via the TETRAEAR_CODEC_TIMEOUT environment
+# variable (in seconds), with a more tolerant default than before.
+def _codec_timeout() -> float:
+    try:
+        value = float(os.environ.get("TETRAEAR_CODEC_TIMEOUT", "15"))
+    except (TypeError, ValueError):
+        value = 15.0
+    return value if value > 0 else 15.0
+
+
+_CODEC_TIMEOUT = _codec_timeout()
+
 
 class VoiceProcessor:
     """
@@ -154,7 +169,11 @@ class VoiceProcessor:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=False,
-                timeout=5,
+                timeout=_CODEC_TIMEOUT,
+                # Run the codec hidden: under a no-console launcher (pythonw)
+                # each call would otherwise flash a console window per frame.
+                # The flag only exists on Windows; elsewhere it is 0 (no-op).
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
             
             # Log codec process output
@@ -207,7 +226,11 @@ class VoiceProcessor:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 check=False,
-                timeout=5,
+                timeout=_CODEC_TIMEOUT,
+                # Run the codec hidden: under a no-console launcher (pythonw)
+                # each call would otherwise flash a console window per frame.
+                # The flag only exists on Windows; elsewhere it is 0 (no-op).
+                creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
             )
 
             if result2.stdout:

--- a/tetraear/ui/modern.py
+++ b/tetraear/ui/modern.py
@@ -1809,6 +1809,16 @@ class CaptureThread(QThread):
         self.pending_freq = None
         self.last_signal_time = 0
         self.encryption_keys = []  # List of keys for bruteforce
+        # CaptureThread uses self.tch_assembler in the voice-decode path
+        # but never created it here, so every voice frame raised
+        # AttributeError. Initialise it so the TCH path is used when
+        # available (falls back to None if the assembler is unavailable).
+        self.tch_assembler = None
+        try:
+            from tetraear.audio.tch import TchFrameAssembler
+            self.tch_assembler = TchFrameAssembler()
+        except Exception:
+            self.tch_assembler = None
         
     def set_keys(self, keys):
         """Set encryption keys for bruteforce attempts."""
@@ -2068,7 +2078,7 @@ class CaptureThread(QThread):
                                 else:
                                     frames = self.decoder.decode(
                                         demodulated,
-                                        confidences=getattr(self.signal_processor, "symbol_confidence", None),
+                                        confidences=getattr(self.processor, "symbol_confidence", None),
                                     )
                                     # Log when frames are found (but limit logging frequency)
                                     if len(frames) > 0:
@@ -2131,7 +2141,7 @@ class CaptureThread(QThread):
 
                                                 # Fallback to symbol-based extraction for legacy paths.
                                                 if codec_input is None and hasattr(self, 'demodulated_symbols') and self.demodulated_symbols is not None:
-                                                    if self.tch_assembler:
+                                                    if getattr(self, "tch_assembler", None):
                                                         codec_input = self.tch_assembler.add_burst(self.demodulated_symbols, frame.get('position'))
                                                     else:
                                                         codec_input = self._extract_voice_slot_from_symbols(frame, self.demodulated_symbols, self.samples_per_symbol)


### PR DESCRIPTION
…odec window

- CaptureThread read a non-existent self.signal_processor (the demodulator is self.processor), raising AttributeError on every frame so nothing was decoded. Use self.processor.
- CaptureThread.tch_assembler was never initialised, raising AttributeError on every voice frame. Initialise it in __init__ (fallback to None) and read it via getattr at the call site.
- Codec per-frame timeout was a hard 5s, dropping decodable frames on slow or cold machines. Make it configurable via TETRAEAR_CODEC_TIMEOUT (default 15s). Also pass creationflags=CREATE_NO_WINDOW so the codec does not flash a console window per frame under a no-console (pythonw) launcher; the flag is 0 (no-op) on non-Windows platforms.